### PR TITLE
Backend functionality for deleting PySyft.FloatTensor 

### DIFF
--- a/Assets/OpenMined/Network/Controllers/SyftController.cs
+++ b/Assets/OpenMined/Network/Controllers/SyftController.cs
@@ -47,6 +47,11 @@ namespace OpenMined.Network.Controllers
 	            string id = tensor.Id.ToString();
 
                 return id;
+            } else if (msgObj.functionCall == "deleteTensor")
+            {
+	            var tensor = tensors[msgObj.objectIndex];
+	            tensors.Remove(msgObj.objectIndex);
+	            tensor.Dispose();
             }
             else
             {

--- a/Assets/OpenMined/Syft/Tensor/FloatTensor.Disposable.cs
+++ b/Assets/OpenMined/Syft/Tensor/FloatTensor.Disposable.cs
@@ -29,6 +29,11 @@ namespace OpenMined.Syft.Tensor
                 data = null;
                 shape = null;
                 strides = null;
+
+                if (dataOnGpu)
+                {
+                    EraseGpu();
+                }
             }
 
             disposed = true;

--- a/Assets/OpenMined/Syft/Tensor/FloatTensor.MemoryOps.cs
+++ b/Assets/OpenMined/Syft/Tensor/FloatTensor.MemoryOps.cs
@@ -24,7 +24,6 @@ namespace OpenMined.Syft.Tensor
             {
                 CopyCputoGpu();
                 EraseCpu();
-                dataOnGpu = true;
             }
         }
 
@@ -34,7 +33,6 @@ namespace OpenMined.Syft.Tensor
             {
                 CopyGpuToCpu();
                 EraseGpu();
-                dataOnGpu = false;
             } 
         }
         
@@ -51,6 +49,8 @@ namespace OpenMined.Syft.Tensor
 
             dataBuffer.SetData(Data);	
             shapeBuffer.SetData(shape);
+            
+            dataOnGpu = true;
         }
 
         private void EraseCpu()
@@ -62,6 +62,7 @@ namespace OpenMined.Syft.Tensor
         {
             dataBuffer.Release();
             shapeBuffer.Release();
+            dataOnGpu = false;
         }
     }
 }


### PR DESCRIPTION
I would be very happy if someone could go through how a tensor is removed and deleted from the server. (e.g. if dispose is used correctly) 

This is the backend support for the destructor and delete methods in PySyft. I couldn't properly test this, since shader functionality is still tightly integrated.