### PR TITLE
Numerical stability for Sigmoid

### DIFF
--- a/UnityProject/Assets/OpenMined.Tests/Editor/FloatTensorTest.cs
+++ b/UnityProject/Assets/OpenMined.Tests/Editor/FloatTensorTest.cs
@@ -718,6 +718,17 @@ public void Sigmoid_()
 	{
 		Assert.AreEqual(sum.Data[i], 1.0f);
 	}
+	
+	float[] data4 = { 1000.0f };
+	int[] data4 = { 1 };	
+	float[] data5 = { -1000.0f };
+	int[] shape5 = { 1 };
+	
+	var tensor4 = new FloatTensor(_ctrl:ctrl, _data:data4, _shape:shape4);
+	var tensor5 = new FloatTensor(_ctrl:ctrl, _data:data5, _shape:shape5);
+	
+	Assert.DoesNotThrow(tensor4.Sigmoid(inline: true));
+	Assert.DoesNotThrow(tensor5.Sigmoid(inline: true));
 }
 
 [Test]

--- a/UnityProject/Assets/OpenMined.Tests/Editor/FloatTensorTest.cs
+++ b/UnityProject/Assets/OpenMined.Tests/Editor/FloatTensorTest.cs
@@ -720,7 +720,7 @@ public void Sigmoid_()
 	}
 	
 	float[] data4 = { 1000.0f };
-	int[] data4 = { 1 };	
+	int[] shape4 = { 1 };	
 	float[] data5 = { -1000.0f };
 	int[] shape5 = { 1 };
 	

--- a/UnityProject/Assets/OpenMined/Syft/Math/Shaders/FloatTensorShaders.compute
+++ b/UnityProject/Assets/OpenMined/Syft/Math/Shaders/FloatTensorShaders.compute
@@ -452,7 +452,12 @@ RWStructuredBuffer<float> SigmoidData_;
 
 [numthreads(1,1,1)]
 void Sigmoid_ (uint3 id : SV_DispatchThreadID) {
-	SigmoidData_[id.x] = 1 / (1 + exp(-SigmoidData_[id.x]));
+	if (SigmoidData_[id.x] >= 0) {
+		SigmoidData_[id.x] = 1 / (1 + exp(-SigmoidData_[id.x]));
+	} else {
+		float tmp = exp(SigmoidData_[id.x]);
+		SigmoidData_[id.x] = tmp / (1 + tmp);
+	}
 }
 
 #pragma kernel Sigmoid
@@ -462,7 +467,12 @@ RWStructuredBuffer<float> SigmoidResult;
 
 [numthreads(1,1,1)]
 void Sigmoid (uint3 id : SV_DispatchThreadID) {
-	SigmoidResult[id.x] = 1 / (1 + exp(-SigmoidData[id.x]));
+	if (SigmoidData_[id.x] >= 0) {
+		SigmoidResult[id.x] = 1 / (1 + exp(-SigmoidData_[id.x]));
+	} else {
+		float tmp = exp(SigmoidData_[id.x]);
+		SigmoidResult[id.x] = tmp / (1 + tmp);
+	}
 }
 
 #pragma kernel Sign

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.Ops.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.Ops.cs
@@ -935,8 +935,14 @@ namespace OpenMined.Syft.Tensor
 				Parallel.For (0, nCpu, workerId => {
 					var max = size * (workerId + 1) / nCpu;
 					for (var i = size * workerId / nCpu; i < max; i++) {
-						double s = Math.Exp ((double)this.Data [i]);
-						result.Data [i] = (float)(s / (1.0f + s));
+						if (this.Data [i] >= 0)
+						{	
+							double s = Math.Exp (-(double)this.Data [i]);
+							result.Data [i] = (float)(1 / (1.0f + s));
+						} else {
+							double s = Math.Exp ((double)this.Data [i]);
+							result.Data [i] = (float)(s / (1.0f + s));
+						}
 					}
 				});
 			}


### PR DESCRIPTION
Introduce checks to Sigmoid evaluation in order to avoid overflow for large data values.

Reference: https://timvieira.github.io/blog/post/2014/02/11/exp-normalize-trick/