### PR TITLE
Compiler warnings are gone (how sad)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ os: osx
 branches:
   only:
   - master
-  - fix/warnings
 
 # send email notifications when the build changes from succeeding to broken
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ os: osx
 branches:
   only:
   - master
+  - fix/warnings
 
 # send email notifications when the build changes from succeeding to broken
 notifications:

--- a/UnityProject/Assets/OpenMined.Tests/Editor/FloatTensorGpuTest.cs
+++ b/UnityProject/Assets/OpenMined.Tests/Editor/FloatTensorGpuTest.cs
@@ -15,14 +15,14 @@ namespace OpenMined.Tests
 
 		public SyftController ctrl;
 
-		[TestFixtureSetUp]
+        [OneTimeSetUp]
 		public void Init()
 		{
 			//Init runs once before running test cases.
 			ctrl = new SyftController(null);
 		}
 
-		[TestFixtureTearDown]
+		[OneTimeTearDown]
 		public void CleanUp()
 		{
 			//CleanUp runs once after all test cases are finished.
@@ -1042,7 +1042,7 @@ namespace OpenMined.Tests
 			// Test division
 			float[] data2 = { float.MinValue, -10, -1.5f, 0, 1.5f, 10, 20, float.MaxValue };
 			int[] shape2 = {2, 4};
-			var tensor2 = new FloatTensor(_ctrl: ctrl, _data: data1, _shape: shape1);
+			var tensor2 = new FloatTensor(_ctrl: ctrl, _data: data2, _shape: shape2);
 
 			scalar = 99;
 			tensor1.Div (scalar, inline: true);
@@ -1769,9 +1769,9 @@ namespace OpenMined.Tests
 			float[] data2 = {1, 2, 3, 4};
 			int[] shape2 = {2, 1, 2, 1};
 
-			var tensor2 = new FloatTensor(_ctrl: ctrl, _data: data1, _shape: shape1);
+			var tensor2 = new FloatTensor(_ctrl: ctrl, _data: data2, _shape: shape2);
 
-			var anotherTensor = tensor2.Squeeze(dim: 3, inline: true);
+			tensor2.Squeeze(dim: 3, inline: true);
 
 			Assert.AreEqual(2, tensor2.Shape[0]);
 			Assert.AreEqual(1, tensor2.Shape[1]);

--- a/UnityProject/Assets/OpenMined.Tests/Editor/FloatTensorGpuTest.cs
+++ b/UnityProject/Assets/OpenMined.Tests/Editor/FloatTensorGpuTest.cs
@@ -16,7 +16,7 @@ namespace OpenMined.Tests
 
 		public SyftController ctrl;
 
-        [OneTimeSetUp]
+		[OneTimeSetUp]
 		public void Init()
 		{
 			//Init runs once before running test cases.

--- a/UnityProject/Assets/OpenMined.Tests/Editor/FloatTensorGpuTest.cs
+++ b/UnityProject/Assets/OpenMined.Tests/Editor/FloatTensorGpuTest.cs
@@ -10,6 +10,7 @@ using UnityEditor.VersionControl;
 namespace OpenMined.Tests
 {
 
+	[Category("FloatTensorGPUTests")]
 	public class FloatTensorGPUTest
 	{
 

--- a/UnityProject/Assets/OpenMined.Tests/Editor/FloatTensorTest.cs
+++ b/UnityProject/Assets/OpenMined.Tests/Editor/FloatTensorTest.cs
@@ -16,14 +16,14 @@ namespace OpenMined.Tests
 
 		public SyftController ctrl;
 
-		[TestFixtureSetUp]
+		[OneTimeSetUp]
 		public void Init()
 		{
 			//Init runs once before running test cases.
 			ctrl = new SyftController(null);
 		}
 
-		[TestFixtureTearDown]
+		[OneTimeTearDown]
 		public void CleanUp()
 		{
 			//CleanUp runs once after all test cases are finished.
@@ -949,13 +949,13 @@ namespace OpenMined.Tests
 			float[] data1 = { -0.4183f, 0.3722f, -0.3091f, 0.4149f, 0.5857f };
 			int[] shape1 = { 5 };
 			var tensor1 = new FloatTensor(_ctrl:ctrl, _data:data1, _shape:shape1);
-		
+
 			float[] data2 = { -0.54180f,  0.31642f, -0.36976f,  0.34706f,  0.46103f };
 			int[] shape2 = { 5 };
 			var tensorLog1p = new FloatTensor(_ctrl:ctrl, _data:data2, _shape:shape2);
-		
+
 			var result = tensor1.Log1p();
-		
+
 			for (int i = 0; i < tensor1.Size; i++)
 			{
 				var rounded = Decimal.Round((Decimal)result.Data[i], 5);
@@ -1643,9 +1643,9 @@ namespace OpenMined.Tests
 			float[] data2 = {1, 2, 3, 4};
 			int[] shape2 = {2, 1, 2, 1};
 
-			var tensor2 = new FloatTensor(_ctrl: ctrl, _data: data1, _shape: shape1);
+			var tensor2 = new FloatTensor(_ctrl: ctrl, _data: data2, _shape: shape2);
 
-			var anotherTensor = tensor2.Squeeze(dim: 3, inline: true);
+			tensor2.Squeeze(dim: 3, inline: true);
 
 			Assert.AreEqual(2, tensor2.Shape[0]);
 			Assert.AreEqual(1, tensor2.Shape[1]);

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.Disposable.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.Disposable.cs
@@ -13,15 +13,15 @@ namespace OpenMined.Syft.Tensor
 		}
 
 		public void Dispose ()
-		{ 
+		{
 			Dispose (true);
-			GC.SuppressFinalize (this);           
+			GC.SuppressFinalize (this);
 		}
 
 		protected virtual void Dispose (bool disposing)
 		{
 			if (disposed)
-				return; 
+				return;
 
 			if (disposing) {
 				data = null;
@@ -39,6 +39,7 @@ namespace OpenMined.Syft.Tensor
 		~FloatTensor ()
 		{
 			Dispose (false);
+#pragma warning disable 420
 			System.Threading.Interlocked.Increment (ref nDeleted);
 		}
 	}

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.Encryption.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.Encryption.cs
@@ -2,7 +2,7 @@ namespace OpenMined.Syft.Tensor
 {
 	public partial class FloatTensor
 	{
-		private bool isEncrypted;
+		private bool isEncrypted = false;
 
 		public bool IsEncrypted {
 			get { return isEncrypted; }

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.ShaderOps.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.ShaderOps.cs
@@ -445,6 +445,9 @@ namespace OpenMined.Syft.Tensor
 			shader.SetBuffer (AddMMKernel_, "AddmmDataB_", tensor_1.DataBuffer);
 			shader.SetBuffer (AddMMKernel_, "AddmmDataC_", tensor_2.DataBuffer);
 			shader.Dispatch (AddMMKernel_, size, 1, 1);
+
+            bufferN.Release();
+            bufferO.Release();
 		}
 
 		public FloatTensor CeilGPU(FloatTensor result)

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.ShaderOps.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.ShaderOps.cs
@@ -446,8 +446,8 @@ namespace OpenMined.Syft.Tensor
 			shader.SetBuffer (AddMMKernel_, "AddmmDataC_", tensor_2.DataBuffer);
 			shader.Dispatch (AddMMKernel_, size, 1, 1);
 
-            bufferN.Release();
-            bufferO.Release();
+			bufferN.Release();
+			bufferO.Release();
 		}
 
 		public FloatTensor CeilGPU(FloatTensor result)

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.cs
@@ -216,6 +216,7 @@ namespace OpenMined.Syft.Tensor
 //			// Lastly: let's set the ID of the tensor.
 //			// IDEs might show a warning, but ref and volatile seems to be working with Interlocked API.
 
+#pragma warning disable 420
             id = System.Threading.Interlocked.Increment(ref nCreated);
 
 


### PR DESCRIPTION
**Rationale**:
- Too many warnings (currently 17) make us finally ignore them. Of course, this can be solved later, but why wait for it? 😉 
- We now have a clean console again, which is a little incentive to keep it clean

What was done:
- Fixed the warnings
- Silenced one kind of warning `CS0420` regarding "ref to volatile" (it cannot be solved otherwise)