### PR TITLE
non-contiguous checks at beginning of functions

### DIFF
--- a/UnityProject/.idea/.idea.UnityProject/.idea/workspace.xml
+++ b/UnityProject/.idea/.idea.UnityProject/.idea/workspace.xml
@@ -2164,220 +2164,220 @@
         <state relative-caret-position="19755">
           <caret line="1319" column="0" lean-forward="false" selection-start-line="1319" selection-start-column="0" selection-end-line="1319" selection-end-column="0" />
           <folding>
-            <marker date="1513306935000" expanded="false" signature="6:92" ph="..." />
-            <marker date="1513306935000" expanded="true" signature="138:89519" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="214:89517" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="308:429" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="486:573" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="618:685" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="736:802" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="914:1544" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1442:1534" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1587:2214" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2112:2204" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2257:2916" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2801:2906" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2960:3586" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3481:3576" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3628:4254" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="4144:4244" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="4297:5110" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="5015:5100" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="5166:7091" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="6183:6605" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="6254:6591" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="6406:6515" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="6659:7081" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="6730:7067" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="6882:6991" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="7152:8232" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="8127:8222" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="8280:8751" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="8645:8741" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="8800:9481" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="9386:9471" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="9540:10034" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="10094:10602" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="10657:11166" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="11222:11745" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="11799:12342" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="12397:12954" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="12997:13657" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="13542:13647" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="13701:14332" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="14226:14322" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="14375:15025" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="14910:15015" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="15069:15690" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="15584:15680" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="15733:16346" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="16245:16336" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="16390:17003" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="16901:16993" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="17046:17444" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="17486:18137" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="18024:18127" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="18180:18803" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="18699:18793" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="18847:19506" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="19391:19496" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="19550:20180" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="20074:20170" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="20233:20623" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="20531:20613" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="20676:21339" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="21140:21329" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="21215:21315" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="21392:22272" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="21954:22262" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="22029:22248" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="22112:22230" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="22330:23019" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="22908:23009" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="23078:23725" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="23630:23715" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="23800:24294" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="24370:24878" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="24949:25458" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="25530:26053" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="26123:26666" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="26737:27294" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="27347:29065" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="27740:27919" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="28118:28209" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="28583:28762" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="28962:29055" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="29119:30837" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="29512:29691" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="29890:29981" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="30355:30534" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="30734:30827" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="30879:31516" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="31397:31506" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="31559:32170" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="32059:32160" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="32214:32840" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="32739:32830" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="32885:33499" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="33397:33489" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="33556:34255" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="33891:34016" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="34291:34697" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="34741:35385" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="35281:35375" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="35430:36074" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="35969:36064" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="36116:38041" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="36178:36242" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="38084:40073" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="38146:38210" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="40115:42040" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="40177:40241" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="42104:42793" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="42682:42783" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="42858:43784" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="43686:43774" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="43865:44359" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="44442:44950" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="45027:45535" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="45613:46135" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="46211:46754" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="46831:47388" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="47447:49149" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="47959:48052" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="48319:48412" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="48680:48773" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="49046:49139" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="49191:49820" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="49719:49810" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="49863:50505" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="50403:50495" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="50548:52489" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="50610:50674" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="52541:53295" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="53194:53285" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="53348:54095" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="53994:54085" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="54149:54985" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="54748:54975" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="55040:55504" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="55403:55494" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="55548:56202" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="56085:56192" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="56247:56880" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="56774:56870" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="56924:57549" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="57442:57539" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="57595:58900" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="58791:58890" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="58947:60351" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="60242:60341" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="60394:61088" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="60986:61078" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="61132:61824" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="61722:61814" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="61866:62520" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="62407:62510" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="62563:63191" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="63086:63181" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="63234:63900" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="63779:63890" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="63944:64581" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="64469:64571" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="64582:65320" ph="/* TODO: not sure why this exists... what was SizeTensor? ... */" />
-            <marker date="1513306935000" expanded="true" signature="65366:66011" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="66058:66861" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="66904:67601" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="67488:67591" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="67659:68579" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="68478:68569" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="68638:69561" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="69459:69551" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="69636:70130" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="70206:70714" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="70785:71294" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="71366:71889" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="71959:72502" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="72573:73130" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="73183:73900" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="73788:73890" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="73954:74672" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="74560:74662" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="74714:76641" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="74776:74840" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="76683:77329" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="77216:77319" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="77372:77992" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="77887:77982" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="78035:78708" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="78593:78698" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="78755:79199" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="79243:79910" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="79960:80926" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="80428:80618" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="80500:80604" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="80722:80916" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="80794:80902" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="80976:82212" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="81466:81772" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="81538:81758" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="81618:81740" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="81884:82202" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="81960:82188" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="82044:82170" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="82280:83207" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="83276:84016" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="84045:87768" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="85276:85365" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="85870:85959" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="86466:86555" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="87067:87156" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="87669:87758" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="87812:88422" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="88312:88412" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="88468:88841" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="88885:89476" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="89374:89466" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="6:92" ph="..." />
+            <marker date="1513349736901" expanded="true" signature="138:89519" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="214:89517" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="308:429" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="486:573" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="618:685" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="736:802" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="914:1544" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="1442:1534" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="1587:2214" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="2112:2204" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="2257:2916" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="2801:2906" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="2960:3586" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="3481:3576" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="3628:4254" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="4144:4244" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="4297:5110" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="5015:5100" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="5166:7091" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="6183:6605" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="6254:6591" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="6406:6515" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="6659:7081" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="6730:7067" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="6882:6991" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="7152:8232" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="8127:8222" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="8280:8751" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="8645:8741" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="8800:9481" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="9386:9471" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="9540:10034" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="10094:10602" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="10657:11166" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="11222:11745" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="11799:12342" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="12397:12954" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="12997:13657" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="13542:13647" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="13701:14332" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="14226:14322" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="14375:15025" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="14910:15015" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="15069:15690" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="15584:15680" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="15733:16346" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="16245:16336" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="16390:17003" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="16901:16993" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="17046:17444" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="17486:18137" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="18024:18127" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="18180:18803" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="18699:18793" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="18847:19506" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="19391:19496" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="19550:20180" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="20074:20170" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="20233:20623" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="20531:20613" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="20676:21339" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="21140:21329" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="21215:21315" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="21392:22272" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="21954:22262" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="22029:22248" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="22112:22230" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="22330:23019" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="22908:23009" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="23078:23725" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="23630:23715" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="23800:24294" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="24370:24878" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="24949:25458" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="25530:26053" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="26123:26666" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="26737:27294" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="27347:29065" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="27740:27919" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="28118:28209" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="28583:28762" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="28962:29055" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="29119:30837" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="29512:29691" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="29890:29981" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="30355:30534" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="30734:30827" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="30879:31516" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="31397:31506" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="31559:32170" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="32059:32160" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="32214:32840" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="32739:32830" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="32885:33499" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="33397:33489" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="33556:34255" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="33891:34016" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="34291:34697" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="34741:35385" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="35281:35375" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="35430:36074" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="35969:36064" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="36116:38041" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="36178:36242" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="38084:40073" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="38146:38210" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="40115:42040" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="40177:40241" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="42104:42793" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="42682:42783" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="42858:43784" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="43686:43774" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="43865:44359" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="44442:44950" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="45027:45535" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="45613:46135" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="46211:46754" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="46831:47388" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="47447:49149" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="47959:48052" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="48319:48412" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="48680:48773" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="49046:49139" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="49191:49820" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="49719:49810" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="49863:50505" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="50403:50495" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="50548:52489" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="50610:50674" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="52541:53295" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="53194:53285" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="53348:54095" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="53994:54085" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="54149:54985" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="54748:54975" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="55040:55504" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="55403:55494" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="55548:56202" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="56085:56192" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="56247:56880" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="56774:56870" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="56924:57549" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="57442:57539" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="57595:58900" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="58791:58890" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="58947:60351" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="60242:60341" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="60394:61088" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="60986:61078" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="61132:61824" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="61722:61814" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="61866:62520" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="62407:62510" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="62563:63191" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="63086:63181" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="63234:63900" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="63779:63890" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="63944:64581" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="64469:64571" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="64582:65320" ph="/* TODO: not sure why this exists... what was SizeTensor? ... */" />
+            <marker date="1513349736901" expanded="true" signature="65366:66011" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="66058:66861" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="66904:67601" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="67488:67591" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="67659:68579" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="68478:68569" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="68638:69561" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="69459:69551" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="69636:70130" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="70206:70714" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="70785:71294" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="71366:71889" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="71959:72502" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="72573:73130" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="73183:73900" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="73788:73890" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="73954:74672" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="74560:74662" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="74714:76641" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="74776:74840" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="76683:77329" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="77216:77319" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="77372:77992" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="77887:77982" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="78035:78708" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="78593:78698" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="78755:79199" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="79243:79910" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="79960:80926" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="80428:80618" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="80500:80604" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="80722:80916" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="80794:80902" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="80976:82212" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="81466:81772" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="81538:81758" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="81618:81740" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="81884:82202" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="81960:82188" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="82044:82170" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="82280:83207" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="83276:84016" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="84045:87768" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="85276:85365" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="85870:85959" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="86466:86555" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="87067:87156" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="87669:87758" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="87812:88422" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="88312:88412" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="88468:88841" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="88885:89476" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="89374:89466" ph="{...}" />
           </folding>
         </state>
       </provider>
@@ -2387,31 +2387,74 @@
         <state relative-caret-position="360">
           <caret line="24" column="33" lean-forward="false" selection-start-line="24" selection-start-column="33" selection-end-line="24" selection-end-column="33" />
           <folding>
-            <marker date="1513306935000" expanded="false" signature="6:210" ph="..." />
-            <marker date="1513306935000" expanded="true" signature="302:5840" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="337:433" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="504:982" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1418:5298" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1640:1700" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1804:1926" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2084:2209" ph="/* Third: let's see what kind of data we've got. We should either have ... */" />
-            <marker date="1513306935000" expanded="true" signature="2287:2376" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2496:2725" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2742:4847" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2773:2882" ph="/* no data seems to be passed in... or its got missing stuff ... */" />
-            <marker date="1513306935000" expanded="true" signature="2917:3000" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3065:3784" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3142:3525" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3550:3766" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3805:4833" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="4032:4117" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="4154:4650" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="4675:4815" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="4849:4994" ph="/* Lastly: let's set the ID of the tensor. ... */" />
-            <marker date="1513306935000" expanded="true" signature="5205:5282" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="5283:5288" ph="/* ... */" />
-            <marker date="1513306935000" expanded="true" signature="5345:5822" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="5614:5709" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="6:210" ph="..." />
+            <marker date="1513349736947" expanded="true" signature="243:33805" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="302:33803" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="337:433" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="504:982" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="1418:5298" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="1640:1700" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="1804:1926" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="2084:2209" ph="/* Third: let's see what kind of data we've got. We should either have ... */" />
+            <marker date="1513349736947" expanded="true" signature="2287:2376" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="2496:2725" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="2742:4847" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="2773:2882" ph="/* no data seems to be passed in... or its got missing stuff ... */" />
+            <marker date="1513349736947" expanded="true" signature="2917:3000" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="3065:3784" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="3142:3525" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="3550:3766" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="3805:4833" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="4032:4117" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="4154:4650" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="4675:4815" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="4849:4994" ph="/* Lastly: let's set the ID of the tensor. ... */" />
+            <marker date="1513349736947" expanded="true" signature="5205:5282" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="5283:5288" ph="/* ... */" />
+            <marker date="1513349736947" expanded="true" signature="5345:5822" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="5614:5709" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="5898:32621" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="5949:32520" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="9409:9584" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="9609:9689" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="13286:17412" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="13649:14042" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="13820:13959" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="14075:14178" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="14561:14942" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="14721:14859" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="14975:15078" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="15260:15646" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="15481:15616" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="15679:15932" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="15772:15902" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="16114:16218" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="17195:17318" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="17601:17727" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="17752:17882" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="21019:21563" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="21176:21328" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="21361:21515" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="23160:23235" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="23430:23521" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="27114:27236" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="27558:27680" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="28706:28981" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="29006:29199" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="29328:29549" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="29574:29711" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="29913:30102" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="30379:30568" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="30845:31034" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="31312:31501" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="31780:31969" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="32175:32328" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="32652:33797" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="32789:32840" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="33269:33665" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="33328:33620" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="33395:33567" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="33703:33761" ph="{...}" />
           </folding>
         </state>
       </provider>
@@ -2444,13 +2487,6 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/Assets/OpenMined/Syft/Tensor/BaseTensor.MemoryOps.cs">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-199">
-          <caret line="0" column="0" lean-forward="false" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/Assets/OpenMined/Network/Servers/NetMqPublisher.cs">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="0">
@@ -2461,20 +2497,6 @@
     <entry file="file://$PROJECT_DIR$/Assets/OpenMined/Syft/Tensor/FloatTensor.Encryption.cs" />
     <entry file="file://$PROJECT_DIR$/Assets/OpenMined/Syft/Tensor/FloatTensor.MemoryOps.cs" />
     <entry file="file://$PROJECT_DIR$/Assets/OpenMined/Syft/Tensor/FloatTensor.Disposable.cs" />
-    <entry file="file://$PROJECT_DIR$/Assets/OpenMined/Syft/Tensor/FloatTensor.Helpers.cs">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="0" column="0" lean-forward="false" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/Assets/OpenMined/Syft/Tensor/BaseTensor.cs">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="375">
-          <caret line="29" column="8" lean-forward="false" selection-start-line="29" selection-start-column="8" selection-end-line="29" selection-end-column="28" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/Assets/OpenMined/Syft/Tensor/Ops/Shaders/TensorOpsShaders.compute">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="0">
@@ -2496,19 +2518,6 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/Assets/OpenMined/Syft/NN/Functional.cs">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="300">
-          <caret line="22" column="29" lean-forward="false" selection-start-line="22" selection-start-column="29" selection-end-line="22" selection-end-column="29" />
-          <folding>
-            <marker date="1513343593000" expanded="false" signature="6:61" ph="..." />
-            <marker date="1513343593000" expanded="true" signature="90:945" ph="{...}" />
-            <marker date="1513343593000" expanded="true" signature="127:943" ph="{...}" />
-            <marker date="1513343593000" expanded="true" signature="248:937" ph="/* public static FloatTensor Softmax(FloatTensor input, int dim = -1) ... */" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/Assets/OpenMined/Network/Utils/Command.cs">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="0">
@@ -2520,33 +2529,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="2055">
           <caret line="144" column="12" lean-forward="false" selection-start-line="144" selection-start-column="12" selection-end-line="144" selection-end-column="12" />
-          <folding>
-            <marker date="1513306935000" expanded="false" signature="6:213" ph="..." />
-            <marker date="1513306935000" expanded="true" signature="255:4005" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="286:4003" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="477:600" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="632:663" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="708:874" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="811:854" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="918:953" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="989:1022" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1059:1085" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1125:1215" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1260:1356" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1395:1458" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1523:1618" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1682:1812" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1866:4000" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2063:3841" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2158:2420" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2470:2543" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2553:2716" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2788:3640" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2885:3211" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3245:3417" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3454:3632" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3651:3769" ph="{...}" />
-          </folding>
         </state>
       </provider>
     </entry>
@@ -2571,217 +2553,11 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/Assets/OpenMined/Syft/Tensor/FloatTensor.ShaderOps.cs">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="0" column="0" lean-forward="false" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding>
-            <marker date="1513306935000" expanded="true" signature="90:42721" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="4181:8430" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="7153:7250" ph="/* PowKernel = shader.FindKernel (&quot;Pow&quot;); ... */" />
-            <marker date="1513306935000" expanded="true" signature="8485:8890" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="8619:8853" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="8921:9226" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="9056:9216" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="9264:9559" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="9591:9738" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="9776:10071" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="10103:10250" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="10288:10583" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="10615:10762" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="10810:11272" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="10952:11262" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="11325:12029" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="11465:12019" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="11521:11800" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="11821:12005" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="12103:12675" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="12244:12638" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="12754:13667" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="12893:13630" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="13025:13397" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="13418:13616" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="13741:13957" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="13994:14284" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="14315:14459" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="14497:14792" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="14824:14971" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="15019:15481" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="15161:15471" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="15534:15943" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="15674:15933" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="16017:16589" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="16158:16552" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="16668:17422" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="16807:17385" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="16863:17230" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="17251:17371" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="17509:18241" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="18297:18584" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="18671:19119" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="19152:19396" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="19434:19762" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="19793:19937" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="19970:20218" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="20275:20697" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="20416:20660" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="20736:21079" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="21112:21360" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="21399:21838" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="21871:22119" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="22167:22629" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="22309:22619" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="22682:23276" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="22822:23266" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="22878:23157" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="23178:23252" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="23350:23922" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="23491:23885" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="24001:24728" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="24140:24691" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="24196:24563" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="24584:24677" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="24776:25238" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="24918:25228" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="25291:25700" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="25431:25690" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="25774:26345" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="25915:26308" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="26425:26944" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="26564:26907" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="26985:27391" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="27022:27355" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="27425:27742" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="27563:27732" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="27781:28182" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="27818:28146" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="28242:28873" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="28388:28863" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="28445:28755" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="28776:28849" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="28959:29718" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="29103:29681" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="29160:29571" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="29592:29667" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="29774:30274" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="29922:30264" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="30354:30973" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="30501:30936" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="30975:32011" ph="/* public FloatTensor PowGPU(float value, FloatTensor result) ... */" />
-            <marker date="1513306935000" expanded="true" signature="32050:32383" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="32418:32676" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="32735:33102" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="33158:33569" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="33293:33532" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="33601:33910" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="33737:33900" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="33947:34237" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="34268:34412" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="34461:34923" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="34603:34913" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="34976:35671" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="35116:35661" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="35172:35451" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="35472:35647" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="35745:36317" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="35886:36280" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="36396:37238" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="36535:37201" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="36667:37039" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="37060:37187" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="37275:37565" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="37596:37740" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="37779:38074" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="38107:39958" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="38130:38370" ph="/* Note: only works for square matrices (as PyTorch does). ... */" />
-            <marker date="1513306935000" expanded="true" signature="39743:39800" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="39996:40291" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="40323:40470" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="40507:41091" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="40569:40645" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="41130:41430" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="41463:41610" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="41644:41953" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="41748:41842" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="41875:41943" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="42037:42349" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="42429:42715" ph="{...}" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/Assets/OpenMined/Syft/Tensor/FloatTensor.cs">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="5325">
-          <caret line="361" column="20" lean-forward="false" selection-start-line="361" selection-start-column="20" selection-end-line="361" selection-end-column="20" />
-          <folding>
-            <marker date="1513306935000" expanded="false" signature="6:210" ph="..." />
-            <marker date="1513306935000" expanded="true" signature="302:5840" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="337:433" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="504:982" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1418:5298" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1640:1700" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1804:1926" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2084:2209" ph="/* Third: let's see what kind of data we've got. We should either have ... */" />
-            <marker date="1513306935000" expanded="true" signature="2287:2376" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2496:2725" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2742:4847" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2773:2882" ph="/* no data seems to be passed in... or its got missing stuff ... */" />
-            <marker date="1513306935000" expanded="true" signature="2917:3000" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3065:3784" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3142:3525" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3550:3766" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3805:4833" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="4032:4117" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="4154:4650" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="4675:4815" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="4849:4994" ph="/* Lastly: let's set the ID of the tensor. ... */" />
-            <marker date="1513306935000" expanded="true" signature="5205:5282" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="5283:5288" ph="/* ... */" />
-            <marker date="1513306935000" expanded="true" signature="5345:5822" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="5614:5709" ph="{...}" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/Assets/OpenMined/Syft/Tensor/FloatTensor.Autograd.cs">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="2685">
           <caret line="180" column="12" lean-forward="false" selection-start-line="180" selection-start-column="12" selection-end-line="180" selection-end-column="12" />
-          <folding>
-            <marker date="1513306935000" expanded="false" signature="6:47" ph="..." />
-            <marker date="1513306935000" expanded="true" signature="119:4971" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="407:583" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="635:858" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="688:823" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="739:809" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="996:1476" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1032:1471" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1599:1828" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1619:1823" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1934:2097" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1954:2093" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2181:4965" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2209:4958" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2242:2350" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2383:2616" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2434:2534" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2547:2607" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2647:2691" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2703:2756" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2845:2942" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2951:3197" ph="/* only continue backpropping if there's something to backprop into ... */" />
-            <marker date="1513306935000" expanded="true" signature="3317:4950" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3365:3487" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3531:3673" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3717:3859" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3903:4024" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="4062:4407" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="4250:4396" ph="/* creators [0].Backward (creators [1].MM (grad.Transpose ()), this); ... */" />
-            <marker date="1513306935000" expanded="true" signature="4450:4620" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="4666:4867" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="4869:4939" ph="/* if (!keepgrads) { ... */" />
-          </folding>
+          <folding />
         </state>
       </provider>
     </entry>
@@ -2789,13 +2565,7 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="465">
           <caret line="31" column="20" lean-forward="false" selection-start-line="31" selection-start-column="20" selection-end-line="31" selection-end-column="20" />
-          <folding>
-            <marker date="1513306935000" expanded="true" signature="6:125" ph="..." />
-            <marker date="1513306935000" expanded="true" signature="157:1130" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="193:1128" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="387:1028" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1086:1124" ph="{...}" />
-          </folding>
+          <folding />
         </state>
       </provider>
     </entry>
@@ -2803,435 +2573,7 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="240">
           <caret line="27" column="0" lean-forward="false" selection-start-line="27" selection-start-column="0" selection-end-line="27" selection-end-column="0" />
-          <folding>
-            <marker date="1513306935000" expanded="false" signature="6:334" ph="..." />
-            <marker date="1513306935000" expanded="true" signature="374:659" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="435:657" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="528:649" ph="{...}" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/Assets/OpenMined/Syft/Tensor/FloatTensor.Ops.cs">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="10800">
-          <caret line="726" column="30" lean-forward="false" selection-start-line="726" selection-start-column="26" selection-end-line="726" selection-end-column="30" />
-          <folding>
-            <marker date="1513306935000" expanded="false" signature="6:190" ph="..." />
-            <marker date="1513306935000" expanded="true" signature="223:35912" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="262:35910" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="315:569" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="326:532" ph="/* FloatTensor result = new FloatTensor(ctrl, _shape:shape, _data:data, _dataBuffer:dataBuffer, _shader:this.shad ... */" />
-            <marker date="1513306935000" expanded="true" signature="706:1181" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="794:882" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="840:877" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="882:1159" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="974:1152" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1077:1146" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1243:2060" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1442:1692" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1461:1635" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1782:1953" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1885:1947" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1980:2036" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2110:2615" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2133:2215" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2178:2210" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2369:2585" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2472:2579" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2665:3163" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2688:2770" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2733:2765" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2916:3132" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3019:3126" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3212:3710" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3235:3317" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3280:3312" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3463:3679" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3566:3673" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3770:4282" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3858:3995" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3940:3990" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3995:4260" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="4087:4253" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="4190:4247" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="4364:5881" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="5123:5177" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="5194:5749" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="5279:5725" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="5392:5719" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="5589:5712" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="5757:5861" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="6026:6527" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="6129:6397" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="6580:6946" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="6617:6747" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="7000:7369" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="7037:7169" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="7437:8374" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="7670:8102" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="7748:8040" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="8119:8248" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="8465:10270" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="9417:9504" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="9530:10083" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="9648:10067" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="9803:10049" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="9888:10027" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="10100:10234" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="10336:10749" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="10438:10634" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="10802:11260" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="10996:11126" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="11315:11720" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="11417:11593" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="11775:12136" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="11878:12009" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="12172:12246" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="12301:12658" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="12402:12527" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="12704:13468" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="12777:12963" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="13208:13272" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="13347:13430" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="13536:14510" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="13770:14210" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="13812:14148" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="13864:14061" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="14227:14356" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="14383:14472" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="14576:14955" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="14679:14839" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="15024:15980" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="15257:15653" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="15299:15591" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="15670:15942" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="15827:15928" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="16048:16846" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="16419:16610" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="16912:17565" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="17167:17363" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="17619:18002" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="17722:17894" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="18038:18373" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="18075:18138" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="18427:18831" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="18530:18704" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="18884:19250" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="18921:19051" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="19292:19689" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="19487:19555" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="19724:20058" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="19761:19823" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="20124:20539" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="20227:20423" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="20592:20958" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="20629:20759" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="21012:21350" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="21049:21111" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="21390:21600" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="21655:21998" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="21692:21755" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="22068:23371" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="22446:22503" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="22905:23331" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="23042:23317" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="23405:24323" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="23450:23640" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="23667:23799" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="23895:24311" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="24032:24297" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="24195:24279" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="24377:24746" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="24414:24546" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="24776:25170" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="25227:26493" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="25264:25600" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="25762:26345" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="25899:26331" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="25955:26122" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="26147:26313" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="26374:26455" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="26564:27699" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="26658:26727" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="26834:27409" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="26876:27123" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="27144:27395" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="27438:27501" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="27518:27662" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="27773:28798" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="28148:28358" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="28273:28344" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="28375:28760" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="28494:28744" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="28626:28725" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="28878:30086" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="29314:29643" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="29392:29509" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="29530:29629" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="29660:30048" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="29779:30032" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="29911:30013" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="30157:30224" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="30253:30421" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="30290:30370" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="30493:31878" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="30570:31023" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="30639:31009" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="30691:30779" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="30804:30991" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="30869:30969" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="31040:31285" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="31109:31271" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="31165:31253" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="31358:31567" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="31401:31553" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="31584:31840" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="31626:31718" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="31739:31826" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="32056:32287" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="32397:32931" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="32585:32919" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="32763:32856" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="33128:34600" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="33200:33276" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="33337:33397" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="33616:34140" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="33659:33738" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="33772:33869" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="33904:34088" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="33955:34039" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="34261:34522" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="34360:34454" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="34668:34852" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="34920:35104" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="35172:35344" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="35413:35585" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="35654:35840" ph="{...}" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/Assets/OpenMined.Tests/Editor/FloatTensor/FloatTensorTest.cs">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="26025">
-          <caret line="1738" column="42" lean-forward="false" selection-start-line="1738" selection-start-column="42" selection-end-line="1738" selection-end-column="42" />
-          <folding>
-            <marker date="1513306935000" expanded="false" signature="6:92" ph="..." />
-            <marker date="1513306935000" expanded="true" signature="138:89519" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="214:89517" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="308:429" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="486:573" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="618:685" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="736:802" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="914:1544" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1442:1534" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1587:2214" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2112:2204" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2257:2916" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2801:2906" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="2960:3586" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3481:3576" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="3628:4254" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="4144:4244" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="4297:5110" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="5015:5100" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="5166:7091" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="6183:6605" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="6254:6591" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="6406:6515" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="6659:7081" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="6730:7067" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="6882:6991" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="7152:8232" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="8127:8222" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="8280:8751" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="8645:8741" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="8800:9481" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="9386:9471" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="9540:10034" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="10094:10602" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="10657:11166" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="11222:11745" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="11799:12342" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="12397:12954" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="12997:13657" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="13542:13647" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="13701:14332" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="14226:14322" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="14375:15025" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="14910:15015" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="15069:15690" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="15584:15680" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="15733:16346" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="16245:16336" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="16390:17003" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="16901:16993" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="17046:17444" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="17486:18137" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="18024:18127" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="18180:18803" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="18699:18793" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="18847:19506" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="19391:19496" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="19550:20180" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="20074:20170" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="20233:20623" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="20531:20613" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="20676:21339" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="21140:21329" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="21215:21315" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="21392:22272" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="21954:22262" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="22029:22248" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="22112:22230" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="22330:23019" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="22908:23009" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="23078:23725" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="23630:23715" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="23800:24294" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="24370:24878" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="24949:25458" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="25530:26053" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="26123:26666" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="26737:27294" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="27347:29065" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="27740:27919" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="28118:28209" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="28583:28762" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="28962:29055" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="29119:30837" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="29512:29691" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="29890:29981" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="30355:30534" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="30734:30827" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="30879:31516" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="31397:31506" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="31559:32170" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="32059:32160" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="32214:32840" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="32739:32830" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="32885:33499" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="33397:33489" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="33556:34255" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="33891:34016" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="34291:34697" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="34741:35385" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="35281:35375" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="35430:36074" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="35969:36064" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="36116:38041" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="36178:36242" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="38084:40073" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="38146:38210" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="40115:42040" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="40177:40241" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="42104:42793" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="42682:42783" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="42858:43784" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="43686:43774" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="43865:44359" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="44442:44950" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="45027:45535" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="45613:46135" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="46211:46754" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="46831:47388" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="47447:49149" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="47959:48052" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="48319:48412" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="48680:48773" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="49046:49139" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="49191:49820" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="49719:49810" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="49863:50505" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="50403:50495" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="50548:52489" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="50610:50674" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="52541:53295" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="53194:53285" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="53348:54095" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="53994:54085" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="54149:54985" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="54748:54975" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="55040:55504" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="55403:55494" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="55548:56202" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="56085:56192" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="56247:56880" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="56774:56870" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="56924:57549" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="57442:57539" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="57595:58900" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="58791:58890" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="58947:60351" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="60242:60341" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="60394:61088" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="60986:61078" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="61132:61824" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="61722:61814" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="61866:62520" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="62407:62510" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="62563:63191" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="63086:63181" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="63234:63900" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="63779:63890" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="63944:64581" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="64469:64571" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="64582:65320" ph="/* TODO: not sure why this exists... what was SizeTensor? ... */" />
-            <marker date="1513306935000" expanded="true" signature="65366:66011" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="66058:66861" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="66904:67601" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="67488:67591" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="67659:68579" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="68478:68569" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="68638:69561" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="69459:69551" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="69636:70130" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="70206:70714" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="70785:71294" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="71366:71889" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="71959:72502" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="72573:73130" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="73183:73900" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="73788:73890" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="73954:74672" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="74560:74662" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="74714:76641" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="74776:74840" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="76683:77329" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="77216:77319" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="77372:77992" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="77887:77982" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="78035:78708" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="78593:78698" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="78755:79199" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="79243:79910" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="79960:80926" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="80428:80618" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="80500:80604" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="80722:80916" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="80794:80902" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="80976:82212" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="81466:81772" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="81538:81758" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="81618:81740" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="81884:82202" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="81960:82188" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="82044:82170" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="82280:83207" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="83276:84016" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="84045:87768" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="85276:85365" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="85870:85959" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="86466:86555" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="87067:87156" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="87669:87758" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="87812:88422" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="88312:88412" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="88468:88841" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="88885:89476" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="89374:89466" ph="{...}" />
-          </folding>
+          <folding />
         </state>
       </provider>
     </entry>
@@ -3239,7 +2581,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="0">
           <caret line="0" column="0" lean-forward="false" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -3247,19 +2588,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="120">
           <caret line="8" column="27" lean-forward="false" selection-start-line="8" selection-start-column="20" selection-end-line="8" selection-end-column="27" />
-          <folding>
-            <marker date="1513306935000" expanded="true" signature="6:54" ph="..." />
-            <marker date="1513306935000" expanded="true" signature="78:1153" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="117:1151" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="211:260" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="282:401" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="426:503" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="529:606" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="681:738" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="771:822" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="864:974" ph="{...}" />
-            <marker date="1513306935000" expanded="true" signature="1049:1145" ph="{...}" />
-          </folding>
         </state>
       </provider>
     </entry>
@@ -3267,12 +2595,771 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="300">
           <caret line="23" column="16" lean-forward="true" selection-start-line="23" selection-start-column="16" selection-end-line="23" selection-end-column="16" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/Assets/OpenMined/Syft/NN/Functional.cs">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="300">
+          <caret line="22" column="29" lean-forward="false" selection-start-line="22" selection-start-column="29" selection-end-line="22" selection-end-column="29" />
           <folding>
-            <marker date="1513343634000" expanded="false" signature="6:92" ph="..." />
-            <marker date="1513343634000" expanded="true" signature="140:3231" ph="{...}" />
-            <marker date="1513343634000" expanded="true" signature="234:3229" ph="{...}" />
-            <marker date="1513343634000" expanded="true" signature="398:520" ph="{...}" />
-            <marker date="1513343634000" expanded="true" signature="530:3223" ph="/* [Test] ... */" />
+            <marker date="1513349736944" expanded="false" signature="6:61" ph="..." />
+            <marker date="1513349736944" expanded="true" signature="90:945" ph="{...}" />
+            <marker date="1513349736944" expanded="true" signature="127:943" ph="{...}" />
+            <marker date="1513349736944" expanded="true" signature="248:937" ph="/* public static FloatTensor Softmax(FloatTensor input, int dim = -1) ... */" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/Assets/OpenMined/Syft/Tensor/FloatTensor.Helpers.cs">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="90">
+          <caret line="7" column="21" lean-forward="false" selection-start-line="7" selection-start-column="21" selection-end-line="7" selection-end-column="21" />
+          <folding>
+            <marker date="1513349736946" expanded="false" signature="6:43" ph="..." />
+            <marker date="1513349736946" expanded="true" signature="76:4667" ph="{...}" />
+            <marker date="1513349736946" expanded="true" signature="115:2365" ph="{...}" />
+            <marker date="1513349736946" expanded="true" signature="201:1351" ph="{...}" />
+            <marker date="1513349736946" expanded="true" signature="300:486" ph="{...}" />
+            <marker date="1513349736946" expanded="true" signature="607:784" ph="{...}" />
+            <marker date="1513349736946" expanded="true" signature="832:1005" ph="{...}" />
+            <marker date="1513349736946" expanded="true" signature="1110:1341" ph="{...}" />
+            <marker date="1513349736946" expanded="true" signature="1173:1327" ph="{...}" />
+            <marker date="1513349736946" expanded="true" signature="1409:1613" ph="{...}" />
+            <marker date="1513349736946" expanded="true" signature="1458:1603" ph="{...}" />
+            <marker date="1513349736946" expanded="true" signature="1688:1780" ph="{...}" />
+            <marker date="1513349736946" expanded="true" signature="1949:2359" ph="{...}" />
+            <marker date="1513349736946" expanded="true" signature="2012:2347" ph="{...}" />
+            <marker date="1513349736946" expanded="true" signature="2191:2284" ph="{...}" />
+            <marker date="1513349736946" expanded="true" signature="2402:4665" ph="{...}" />
+            <marker date="1513349736946" expanded="true" signature="2535:3192" ph="{...}" />
+            <marker date="1513349736946" expanded="true" signature="2753:3180" ph="{...}" />
+            <marker date="1513349736946" expanded="true" signature="2926:2996" ph="{...}" />
+            <marker date="1513349736946" expanded="true" signature="3014:3166" ph="/* shows the ranges preccessed by each thread ... */" />
+            <marker date="1513349736946" expanded="true" signature="3320:4659" ph="{...}" />
+            <marker date="1513349736946" expanded="true" signature="3430:3554" ph="/* only use as many threads as needed (MAX array length / 2) ... */" />
+            <marker date="1513349736946" expanded="true" signature="3675:4580" ph="{...}" />
+            <marker date="1513349736946" expanded="true" signature="3816:4400" ph="{...}" />
+            <marker date="1513349736946" expanded="true" signature="4052:4155" ph="{...}" />
+            <marker date="1513349736946" expanded="true" signature="4220:4382" ph="/* shows the number of items preccessed by each thread ... */" />
+            <marker date="1513349736946" expanded="true" signature="4450:4566" ph="/* show when a reduce iteration completes ... */" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/Assets/OpenMined/Syft/Tensor/FloatTensor.cs">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="-15274">
+          <caret line="4" column="6" lean-forward="false" selection-start-line="4" selection-start-column="6" selection-end-line="4" selection-end-column="29" />
+          <folding>
+            <marker date="1513349736947" expanded="true" signature="6:210" ph="..." />
+            <marker date="1513349736947" expanded="true" signature="243:33805" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="302:33803" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="337:433" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="504:982" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="1418:5298" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="1640:1700" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="1804:1926" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="2084:2209" ph="/* Third: let's see what kind of data we've got. We should either have ... */" />
+            <marker date="1513349736947" expanded="true" signature="2287:2376" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="2496:2725" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="2742:4847" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="2773:2882" ph="/* no data seems to be passed in... or its got missing stuff ... */" />
+            <marker date="1513349736947" expanded="true" signature="2917:3000" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="3065:3784" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="3142:3525" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="3550:3766" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="3805:4833" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="4032:4117" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="4154:4650" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="4675:4815" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="4849:4994" ph="/* Lastly: let's set the ID of the tensor. ... */" />
+            <marker date="1513349736947" expanded="true" signature="5205:5282" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="5283:5288" ph="/* ... */" />
+            <marker date="1513349736947" expanded="true" signature="5345:5822" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="5614:5709" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="5898:32621" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="5949:32520" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="9409:9584" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="9609:9689" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="13286:17412" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="13649:14042" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="13820:13959" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="14075:14178" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="14561:14942" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="14721:14859" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="14975:15078" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="15260:15646" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="15481:15616" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="15679:15932" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="15772:15902" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="16114:16218" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="17195:17318" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="17601:17727" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="17752:17882" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="21019:21563" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="21176:21328" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="21361:21515" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="23160:23235" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="23430:23521" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="27114:27236" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="27558:27680" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="28706:28981" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="29006:29199" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="29328:29549" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="29574:29711" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="29913:30102" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="30379:30568" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="30845:31034" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="31312:31501" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="31780:31969" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="32175:32328" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="32652:33797" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="32789:32840" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="33269:33665" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="33328:33620" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="33395:33567" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="33703:33761" ph="{...}" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/Assets/OpenMined/Syft/Tensor/FloatTensor.ShaderOps.cs">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="1290">
+          <caret line="86" column="4" lean-forward="false" selection-start-line="86" selection-start-column="4" selection-end-line="86" selection-end-column="4" />
+          <folding>
+            <marker date="1513349736947" expanded="true" signature="51:42723" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="90:42721" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="4181:8430" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="7153:7250" ph="/* PowKernel = shader.FindKernel (&quot;Pow&quot;); ... */" />
+            <marker date="1513349736947" expanded="true" signature="8485:8890" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="8619:8853" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="8921:9226" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="9056:9216" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="9264:9559" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="9591:9738" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="9776:10071" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="10103:10250" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="10288:10583" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="10615:10762" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="10810:11272" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="10952:11262" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="11325:12029" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="11465:12019" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="11521:11800" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="11821:12005" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="12103:12675" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="12244:12638" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="12754:13667" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="12893:13630" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="13025:13397" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="13418:13616" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="13741:13957" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="13994:14284" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="14315:14459" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="14497:14792" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="14824:14971" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="15019:15481" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="15161:15471" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="15534:15943" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="15674:15933" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="16017:16589" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="16158:16552" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="16668:17422" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="16807:17385" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="16863:17230" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="17251:17371" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="17509:18241" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="18297:18584" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="18671:19119" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="19152:19396" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="19434:19762" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="19793:19937" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="19970:20218" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="20275:20697" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="20416:20660" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="20736:21079" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="21112:21360" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="21399:21838" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="21871:22119" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="22167:22629" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="22309:22619" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="22682:23276" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="22822:23266" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="22878:23157" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="23178:23252" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="23350:23922" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="23491:23885" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="24001:24728" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="24140:24691" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="24196:24563" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="24584:24677" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="24776:25238" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="24918:25228" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="25291:25700" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="25431:25690" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="25774:26345" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="25915:26308" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="26425:26944" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="26564:26907" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="26985:27391" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="27022:27355" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="27425:27742" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="27563:27732" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="27781:28182" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="27818:28146" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="28242:28873" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="28388:28863" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="28445:28755" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="28776:28849" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="28959:29718" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="29103:29681" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="29160:29571" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="29592:29667" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="29774:30274" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="29922:30264" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="30354:30973" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="30501:30936" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="30975:32011" ph="/* public FloatTensor PowGPU(float value, FloatTensor result) ... */" />
+            <marker date="1513349736947" expanded="true" signature="32050:32383" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="32418:32676" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="32735:33102" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="33158:33569" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="33293:33532" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="33601:33910" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="33737:33900" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="33947:34237" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="34268:34412" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="34461:34923" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="34603:34913" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="34976:35671" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="35116:35661" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="35172:35451" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="35472:35647" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="35745:36317" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="35886:36280" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="36396:37238" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="36535:37201" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="36667:37039" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="37060:37187" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="37275:37565" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="37596:37740" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="37779:38074" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="38107:39958" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="38130:38370" ph="/* Note: only works for square matrices (as PyTorch does). ... */" />
+            <marker date="1513349736947" expanded="true" signature="39743:39800" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="39996:40291" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="40323:40470" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="40507:41091" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="40569:40645" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="41130:41430" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="41463:41610" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="41644:41953" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="41748:41842" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="41875:41943" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="42037:42349" ph="{...}" />
+            <marker date="1513349736947" expanded="true" signature="42429:42715" ph="{...}" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/Assets/OpenMined.Tests/Editor/FloatTensor/FloatTensorTest.cs">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="2058">
+          <caret line="2381" column="0" lean-forward="false" selection-start-line="2381" selection-start-column="0" selection-end-line="2381" selection-end-column="0" />
+          <folding>
+            <marker date="1513349736901" expanded="true" signature="6:92" ph="..." />
+            <marker date="1513349736901" expanded="true" signature="138:89519" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="214:89517" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="308:429" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="486:573" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="618:685" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="736:802" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="914:1544" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="1442:1534" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="1587:2214" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="2112:2204" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="2257:2916" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="2801:2906" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="2960:3586" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="3481:3576" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="3628:4254" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="4144:4244" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="4297:5110" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="5015:5100" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="5166:7091" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="6183:6605" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="6254:6591" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="6406:6515" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="6659:7081" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="6730:7067" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="6882:6991" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="7152:8232" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="8127:8222" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="8280:8751" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="8645:8741" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="8800:9481" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="9386:9471" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="9540:10034" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="10094:10602" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="10657:11166" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="11222:11745" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="11799:12342" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="12397:12954" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="12997:13657" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="13542:13647" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="13701:14332" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="14226:14322" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="14375:15025" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="14910:15015" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="15069:15690" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="15584:15680" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="15733:16346" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="16245:16336" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="16390:17003" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="16901:16993" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="17046:17444" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="17486:18137" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="18024:18127" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="18180:18803" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="18699:18793" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="18847:19506" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="19391:19496" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="19550:20180" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="20074:20170" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="20233:20623" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="20531:20613" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="20676:21339" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="21140:21329" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="21215:21315" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="21392:22272" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="21954:22262" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="22029:22248" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="22112:22230" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="22330:23019" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="22908:23009" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="23078:23725" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="23630:23715" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="23800:24294" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="24370:24878" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="24949:25458" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="25530:26053" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="26123:26666" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="26737:27294" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="27347:29065" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="27740:27919" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="28118:28209" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="28583:28762" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="28962:29055" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="29119:30837" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="29512:29691" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="29890:29981" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="30355:30534" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="30734:30827" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="30879:31516" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="31397:31506" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="31559:32170" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="32059:32160" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="32214:32840" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="32739:32830" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="32885:33499" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="33397:33489" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="33556:34255" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="33891:34016" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="34291:34697" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="34741:35385" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="35281:35375" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="35430:36074" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="35969:36064" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="36116:38041" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="36178:36242" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="38084:40073" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="38146:38210" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="40115:42040" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="40177:40241" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="42104:42793" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="42682:42783" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="42858:43784" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="43686:43774" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="43865:44359" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="44442:44950" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="45027:45535" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="45613:46135" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="46211:46754" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="46831:47388" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="47447:49149" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="47959:48052" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="48319:48412" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="48680:48773" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="49046:49139" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="49191:49820" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="49719:49810" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="49863:50505" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="50403:50495" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="50548:52489" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="50610:50674" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="52541:53295" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="53194:53285" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="53348:54095" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="53994:54085" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="54149:54985" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="54748:54975" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="55040:55504" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="55403:55494" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="55548:56202" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="56085:56192" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="56247:56880" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="56774:56870" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="56924:57549" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="57442:57539" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="57595:58900" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="58791:58890" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="58947:60351" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="60242:60341" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="60394:61088" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="60986:61078" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="61132:61824" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="61722:61814" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="61866:62520" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="62407:62510" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="62563:63191" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="63086:63181" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="63234:63900" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="63779:63890" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="63944:64581" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="64469:64571" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="64582:65320" ph="/* TODO: not sure why this exists... what was SizeTensor? ... */" />
+            <marker date="1513349736901" expanded="true" signature="65366:66011" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="66058:66861" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="66904:67601" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="67488:67591" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="67659:68579" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="68478:68569" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="68638:69561" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="69459:69551" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="69636:70130" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="70206:70714" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="70785:71294" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="71366:71889" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="71959:72502" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="72573:73130" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="73183:73900" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="73788:73890" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="73954:74672" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="74560:74662" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="74714:76641" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="74776:74840" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="76683:77329" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="77216:77319" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="77372:77992" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="77887:77982" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="78035:78708" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="78593:78698" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="78755:79199" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="79243:79910" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="79960:80926" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="80428:80618" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="80500:80604" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="80722:80916" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="80794:80902" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="80976:82212" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="81466:81772" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="81538:81758" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="81618:81740" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="81884:82202" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="81960:82188" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="82044:82170" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="82280:83207" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="83276:84016" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="84045:87768" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="85276:85365" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="85870:85959" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="86466:86555" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="87067:87156" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="87669:87758" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="87812:88422" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="88312:88412" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="88468:88841" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="88885:89476" ph="{...}" />
+            <marker date="1513349736901" expanded="true" signature="89374:89466" ph="{...}" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/Assets/OpenMined/Syft/Tensor/BaseTensor.MemoryOps.cs">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="0">
+          <caret line="0" column="0" lean-forward="false" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding>
+            <marker date="1513349736945" expanded="false" signature="6:56" ph="..." />
+            <marker date="1513349736945" expanded="true" signature="89:1679" ph="{...}" />
+            <marker date="1513349736945" expanded="true" signature="139:1677" ph="{...}" />
+            <marker date="1513349736945" expanded="true" signature="355:454" ph="{...}" />
+            <marker date="1513349736945" expanded="true" signature="496:597" ph="{...}" />
+            <marker date="1513349736945" expanded="true" signature="645:851" ph="{...}" />
+            <marker date="1513349736945" expanded="true" signature="878:986" ph="{...}" />
+            <marker date="1513349736945" expanded="true" signature="1025:1115" ph="{...}" />
+            <marker date="1513349736945" expanded="true" signature="1154:1434" ph="{...}" />
+            <marker date="1513349736945" expanded="true" signature="1469:1514" ph="{...}" />
+            <marker date="1513349736945" expanded="true" signature="1549:1671" ph="{...}" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/Assets/OpenMined/Syft/Tensor/BaseTensor.cs">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="675">
+          <caret line="166" column="5" lean-forward="false" selection-start-line="166" selection-start-column="5" selection-end-line="166" selection-end-column="5" />
+          <folding>
+            <marker date="1513356703313" expanded="false" signature="6:141" ph="..." />
+            <marker date="1513356703313" expanded="true" signature="174:4457" ph="{...}" />
+            <marker date="1513356703313" expanded="true" signature="224:4455" ph="{...}" />
+            <marker date="1513356703313" expanded="true" signature="239:393" ph="Statics" />
+            <marker date="1513356703313" expanded="true" signature="403:672" ph="Members" />
+            <marker date="1513356703313" expanded="true" signature="682:1632" ph="Properties" />
+            <marker date="1513356703313" expanded="true" signature="742:841" ph="{...}" />
+            <marker date="1513356703313" expanded="true" signature="866:963" ph="{...}" />
+            <marker date="1513356703313" expanded="true" signature="991:1090" ph="{...}" />
+            <marker date="1513356703313" expanded="true" signature="1120:1223" ph="{...}" />
+            <marker date="1513356703313" expanded="true" signature="1248:1345" ph="{...}" />
+            <marker date="1513356703313" expanded="true" signature="1368:1461" ph="{...}" />
+            <marker date="1513356703313" expanded="true" signature="1507:1612" ph="{...}" />
+            <marker date="1513356703313" expanded="true" signature="1688:2001" ph="{...}" />
+            <marker date="1513356703313" expanded="true" signature="1844:1916" ph="{...}" />
+            <marker date="1513356703313" expanded="true" signature="1933:1991" ph="{...}" />
+            <marker date="1513356703313" expanded="true" signature="2136:3249" ph="{...}" />
+            <marker date="1513356703313" expanded="true" signature="2342:2404" ph="{...}" />
+            <marker date="1513356703313" expanded="true" signature="2421:2567" ph="{...}" />
+            <marker date="1513356703313" expanded="true" signature="2607:3116" ph="{...}" />
+            <marker date="1513356703313" expanded="true" signature="3259:4449" ph="Operators" />
+            <marker date="1513356703313" expanded="true" signature="3327:3752" ph="{...}" />
+            <marker date="1513356703313" expanded="true" signature="3516:3715" ph="{...}" />
+            <marker date="1513356703313" expanded="true" signature="3796:4124" ph="{...}" />
+            <marker date="1513356703313" expanded="true" signature="3938:4086" ph="{...}" />
+            <marker date="1513356703313" expanded="true" signature="4169:4294" ph="{...}" />
+            <marker date="1513356703313" expanded="true" signature="4328:4429" ph="{...}" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/Assets/OpenMined/Syft/Tensor/FloatTensor.Ops.cs">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="326">
+          <caret line="404" column="33" lean-forward="false" selection-start-line="404" selection-start-column="33" selection-end-line="404" selection-end-column="33" />
+          <folding>
+            <marker date="1513356865711" expanded="true" signature="6:190" ph="..." />
+            <marker date="1513356865711" expanded="true" signature="223:39453" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="262:39451" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="315:569" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="326:532" ph="/* FloatTensor result = new FloatTensor(ctrl, _shape:shape, _data:data, _dataBuffer:dataBuffer, _shader:this.shad ... */" />
+            <marker date="1513356865711" expanded="true" signature="706:1181" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="794:882" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="840:877" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="882:1159" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="974:1152" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="1077:1146" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="1243:2231" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="1296:1417" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="1613:1863" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="1632:1806" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="1953:2124" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="2056:2118" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="2151:2207" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="2281:2786" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="2304:2386" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="2349:2381" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="2540:2756" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="2643:2750" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="2836:3334" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="2859:2941" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="2904:2936" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="3087:3303" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="3190:3297" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="3383:3881" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="3406:3488" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="3451:3483" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="3634:3850" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="3737:3844" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="3941:4453" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="4029:4166" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="4111:4161" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="4166:4431" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="4258:4424" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="4361:4418" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="4535:6258" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="4621:4741" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="5500:5554" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="5571:6126" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="5656:6102" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="5769:6096" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="5966:6089" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="6134:6238" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="6403:6904" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="6506:6774" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="6957:7323" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="6994:7124" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="7377:7746" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="7414:7546" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="7814:8935" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="7879:8007" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="8231:8663" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="8309:8601" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="8680:8809" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="9026:11058" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="9122:9250" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="10205:10292" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="10318:10871" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="10436:10855" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="10591:10837" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="10676:10815" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="10888:11022" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="11124:11537" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="11226:11422" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="11590:12048" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="11784:11914" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="12103:12508" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="12205:12381" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="12563:12924" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="12666:12797" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="12960:13194" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="13015:13117" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="13050:13103" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="13249:13606" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="13350:13475" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="13652:14605" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="13717:13850" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="13914:14100" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="14345:14409" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="14484:14567" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="14673:15836" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="14738:14871" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="15096:15536" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="15138:15474" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="15190:15387" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="15553:15682" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="15709:15798" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="15902:16281" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="16005:16165" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="16350:17495" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="16415:16548" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="16772:17168" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="16814:17106" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="17185:17457" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="17342:17443" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="17563:18550" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="17628:17761" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="18123:18314" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="18616:19269" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="18871:19067" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="19323:19706" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="19426:19598" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="19742:20077" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="19779:19842" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="20131:20535" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="20234:20408" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="20588:20954" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="20625:20755" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="20996:21393" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="21191:21259" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="21428:21762" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="21465:21527" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="21828:22243" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="21931:22127" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="22296:22662" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="22333:22463" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="22716:23054" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="22753:22815" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="23094:23304" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="23359:23702" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="23396:23459" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="23772:25238" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="23816:23944" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="24313:24370" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="24772:25198" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="24909:25184" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="25272:26353" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="25316:25444" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="25480:25670" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="25697:25829" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="25925:26341" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="26062:26327" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="26225:26309" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="26407:26776" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="26444:26576" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="26806:27200" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="27257:28523" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="27294:27630" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="27792:28375" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="27929:28361" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="27985:28152" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="28177:28343" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="28404:28485" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="28594:29892" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="28638:28766" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="28851:28920" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="29027:29602" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="29069:29316" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="29337:29588" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="29631:29694" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="29711:29855" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="29966:30991" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="30341:30551" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="30466:30537" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="30568:30953" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="30687:30937" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="30819:30918" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="31071:32473" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="31142:31274" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="31701:32030" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="31779:31896" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="31917:32016" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="32047:32435" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="32166:32419" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="32298:32400" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="32544:32611" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="32640:32971" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="32684:32812" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="32840:32920" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="33043:34592" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="33088:33216" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="33284:33737" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="33353:33723" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="33405:33493" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="33518:33705" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="33583:33683" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="33754:33999" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="33823:33985" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="33879:33967" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="34072:34281" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="34115:34267" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="34298:34554" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="34340:34432" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="34453:34540" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="34770:35001" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="35111:35645" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="35299:35633" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="35477:35570" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="35842:37314" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="35914:35990" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="36051:36111" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="36330:36854" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="36373:36452" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="36486:36583" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="36618:36802" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="36669:36753" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="36975:37236" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="37074:37168" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="37382:37729" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="37426:37554" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="37797:38144" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="37841:37969" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="38212:38547" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="38256:38384" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="38616:38963" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="38660:38788" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="39032:39381" ph="{...}" />
+            <marker date="1513356865711" expanded="true" signature="39076:39204" ph="{...}" />
           </folding>
         </state>
       </provider>

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.Ops.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.Ops.cs
@@ -40,6 +40,10 @@ namespace OpenMined.Syft.Tensor
 
 		public FloatTensor Add(FloatTensor x, bool inline = false)
 		{
+		    if (!IsContiguous() || !x.IsContiguous()) {
+		        throw new InvalidOperationException ("All tensors must be contiguous, call Contiguous() to convert");
+		    }
+
 			// Check if both tensors are compatible for sum
 			SameSizeDimensionsShapeAndLocation(ref x);
 
@@ -159,7 +163,11 @@ namespace OpenMined.Syft.Tensor
 
 		public FloatTensor AddMatrixMultiply(FloatTensor tensor1, FloatTensor tensor2)
 		{
-			bool gpu = dataOnGpu & tensor1.DataOnGpu & tensor2.DataOnGpu;
+		    if (!IsContiguous() || !tensor1.IsContiguous() || !tensor2.IsContiguous()) {
+		        throw new InvalidOperationException("All tensors must be contiguous, call Contiguous() to convert");
+		    }
+
+		    bool gpu = dataOnGpu & tensor1.DataOnGpu & tensor2.DataOnGpu;
 			bool cpu = !(dataOnGpu | tensor1.DataOnGpu | tensor2.DataOnGpu);
 
 			int[] res_shape = this.Shape;
@@ -250,6 +258,10 @@ namespace OpenMined.Syft.Tensor
 
         public FloatTensor Div(FloatTensor x, bool inline = false)
         {
+            if (!IsContiguous() || !x.IsContiguous()) {
+                throw new InvalidOperationException ("Tensor must be contiguous, call Contiguous() to convert");
+            }
+
             // Check if both tensors are compatible for sum
             SameSizeDimensionsShapeAndLocation(ref x);
 
@@ -281,6 +293,10 @@ namespace OpenMined.Syft.Tensor
 
         public FloatTensor AddMatrixVectorProduct(FloatTensor matrix, FloatTensor vector)
         {
+            if (!IsContiguous() || !matrix.IsContiguous() || !vector.IsContiguous()) {
+                throw new InvalidOperationException ("Tensor must be contiguous, call Contiguous() to convert");
+            }
+            
             var gpu = dataOnGpu & matrix.DataOnGpu & vector.DataOnGpu;
             var cpu = !(dataOnGpu | matrix.DataOnGpu | vector.DataOnGpu);
 
@@ -384,6 +400,12 @@ namespace OpenMined.Syft.Tensor
 
         public bool IsContiguous()
         {
+            foreach (var stride in strides) {
+                if (stride == 0) {
+                    return false;
+                }
+            }
+            
             return strides[strides.Length - 1] == 1L;
         }
 
@@ -403,6 +425,10 @@ namespace OpenMined.Syft.Tensor
 
         public FloatTensor MM(FloatTensor x)
         {
+            if (!IsContiguous() || !x.IsContiguous()) {
+                throw new InvalidOperationException ("All tensors must be contiguous, call Contiguous() to convert");
+            }
+
             if (this.shape.Length != 2 || x.shape.Length != 2)
             {
                 throw new InvalidOperationException(
@@ -432,6 +458,10 @@ namespace OpenMined.Syft.Tensor
 
         public FloatTensor Mul(FloatTensor x, bool inline = false)
         {
+            if (!IsContiguous() || !x.IsContiguous()) {
+                throw new InvalidOperationException ("All tensors must be contiguous, call Contiguous() to convert");
+            }
+
             // Check if both tensors are compatible for sum
             SameSizeDimensionsShapeAndLocation(ref x);
 
@@ -482,6 +512,10 @@ namespace OpenMined.Syft.Tensor
 
         public FloatTensor Sub(FloatTensor x, bool inline = false)
         {
+            if (!IsContiguous() || !x.IsContiguous()) {
+                throw new InvalidOperationException ("All tensors must be contiguous, call Contiguous() to convert");
+            }
+
             // Check if both tensors are compatible for sum
             SameSizeDimensionsShapeAndLocation(ref x);
 
@@ -514,6 +548,10 @@ namespace OpenMined.Syft.Tensor
 
         public FloatTensor Pow(FloatTensor x, bool inline = false)
         {
+            if (!IsContiguous() || !x.IsContiguous()) {
+                throw new InvalidOperationException ("All tensors must be contiguous, call Contiguous() to convert");
+            }
+
             // Check if both tensors are compatible for sum
             SameSizeDimensionsShapeAndLocation(ref x);
 
@@ -704,6 +742,10 @@ namespace OpenMined.Syft.Tensor
 
         public FloatTensor Transpose(int dimension1, int dimension2)
         {
+            if (!IsContiguous()) {
+                throw new InvalidOperationException ("Tensor must be contiguous, call Contiguous() to convert");
+            }
+
             //TODO: Should we create a new Tensor object here?
             if (dimension1 < 0 || dimension1 >= shape.Length)
                 throw new ArgumentOutOfRangeException("dimension1");
@@ -740,6 +782,10 @@ namespace OpenMined.Syft.Tensor
 
         public void Triu_(int k)
         {
+            if (!IsContiguous()) {
+                throw new InvalidOperationException ("Tensor must be contiguous, call Contiguous() to convert");
+            }
+
             if (shape.Length != 2)
             {
                 throw new InvalidOperationException(
@@ -834,6 +880,10 @@ namespace OpenMined.Syft.Tensor
 
         public FloatTensor View(int[] new_shape, bool inline = false)
         {
+            if (!IsContiguous()) {
+                throw new InvalidOperationException ("Tensor must be contiguous, call Contiguous() to convert");
+            }
+
             var newSize = 1;
             for (var i = 0; i < new_shape.Length; i++)
             {
@@ -902,6 +952,10 @@ namespace OpenMined.Syft.Tensor
 
         public FloatTensor Remainder(FloatTensor divisor, bool inline = false)
         {
+            if (!IsContiguous() || !divisor.IsContiguous()) {
+                throw new InvalidOperationException ("All tensor must be contiguous, call Contiguous() to convert");
+            }
+
             SameSizeDimensionsShapeAndLocation(ref divisor);
             if (inline & autograd)
                 throw new InvalidOperationException("Cannot call inline functions if you intend to run backprop.");
@@ -945,6 +999,10 @@ namespace OpenMined.Syft.Tensor
 
         public void Zero_()
         {
+            if (!IsContiguous()) {
+                throw new InvalidOperationException ("Tensor must be contiguous, call Contiguous() to convert");
+            }
+
             if (dataOnGpu)
             {
                 ZeroGPU_();
@@ -957,6 +1015,10 @@ namespace OpenMined.Syft.Tensor
 
         public FloatTensor Squeeze(int dim = -1, bool inline = false)
         {
+            if (!IsContiguous()) {
+                throw new InvalidOperationException ("Tensor must be contiguous, call Contiguous() to convert");
+            }
+
             var list = new List<int>();
 
             if (dim >= 0)
@@ -1115,30 +1177,50 @@ namespace OpenMined.Syft.Tensor
 
         public FloatTensor Min(int dim = -1, bool keepdim = false)
         {
+            if (!IsContiguous()) {
+                throw new InvalidOperationException ("Tensor must be contiguous, call Contiguous() to convert");
+            }
+
             // TODO: Implement GPU op. with GPU tests.
             return Reduce(dim, keepdim, (acc, val, index, arr) => acc < val ? acc : val, (val, len) => val);
         }
 
         public FloatTensor Max(int dim = -1, bool keepdim = false)
         {
+            if (!IsContiguous()) {
+                throw new InvalidOperationException ("Tensor must be contiguous, call Contiguous() to convert");
+            }
+
             // TODO: Implement GPU op. with GPU tests.
             return Reduce(dim, keepdim, (acc, val, index, arr) => acc > val ? acc : val, (val, len) => val);
         }
 
         public FloatTensor Sum(int dim = -1, bool keepdim = false)
         {
+            if (!IsContiguous()) {
+                throw new InvalidOperationException ("Tensor must be contiguous, call Contiguous() to convert");
+            }
+
             // TODO: Implement GPU op. with GPU tests.
             return Reduce(dim, keepdim, (acc, val, index, arr) => acc + val, (val, len) => val);
         }
 
         public FloatTensor Prod(int dim = -1, bool keepdim = false)
         {
+            if (!IsContiguous()) {
+                throw new InvalidOperationException ("Tensor must be contiguous, call Contiguous() to convert");
+            }
+            
             // TODO: Implement GPU op. with GPU tests.
             return Reduce(dim, keepdim, (acc, val, index, arr) => acc * val, (val, len) => val);
         }
 
         public FloatTensor Mean(int dim = -1, bool keepdim = false)
         {
+            if (!IsContiguous()) {
+                throw new InvalidOperationException ("Tensor must be contiguous, call Contiguous() to convert");
+            }
+
             // TODO: Implement GPU op. with GPU tests.
             return Reduce(dim, keepdim, (acc, val, index, arr) => acc + val, (val, len) => val / (float) len);
         }


### PR DESCRIPTION
This pr adds a contiguous checks at the beginning of most functions. Most of our
functions don't support non-contiguous tensors.

Also changed the definition of IsContiguous a bit. Noticed that in
pytorh a contiguous tensor must have its last dimension's stride set to
1 AND not have other strides set to zero. If this doesn't work let me
know!

Another thing that is needed in the future is a function to turn a
non-contiguous tensor into a contiguous one. Not really sure how to
implement this right now.

Check out this discussion for more: https://github.com/OpenMined/OpenMined/issues/205