### PR TITLE
Feature/embedding

### DIFF
--- a/UnityProject/Assets/OpenMined/Network/Controllers/SyftController.cs
+++ b/UnityProject/Assets/OpenMined/Network/Controllers/SyftController.cs
@@ -211,6 +211,10 @@ namespace OpenMined.Network.Controllers
 							{
 								return new MSELoss(this).Id.ToString();
 							}
+                            else if (model_type == "embedding")
+                            {
+                                return new Embedding(this, int.Parse(msgObj.tensorIndexParams[1]), int.Parse(msgObj.tensorIndexParams[2])).Id.ToString();
+                            }
 							else
 							{
 								Debug.LogFormat("<color=red>Model Type Not Found:</color> {0}", model_type);

--- a/UnityProject/Assets/OpenMined/Syft/NN/Embedding.cs
+++ b/UnityProject/Assets/OpenMined/Syft/NN/Embedding.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using OpenMined.Network.Controllers;
+using OpenMined.Syft.Tensor;
+
+namespace OpenMined.Syft.Layer
+{
+    public class Embedding : Layer
+    {
+        private int _numEmbeddings;
+        private int _embeddingDim;
+
+        private readonly FloatTensor _weights;
+    
+        public Embedding(SyftController controller, int numEmbeddings, int embeddingDim)
+        {
+            init("embedding");
+
+            this.controller = controller;
+
+            _numEmbeddings = numEmbeddings;
+            _embeddingDim = embeddingDim;
+
+            int[] weightShape = { _numEmbeddings, _embeddingDim };
+            var weights = controller.RandomWeights(_numEmbeddings * _embeddingDim);
+            _weights = controller.floatTensorFactory.Create(_shape: weightShape, _data: weights, _autograd: true, _keepgrads: true);
+
+            parameters.Add(_weights.Id);
+
+            #pragma warning disable 420
+            id = System.Threading.Interlocked.Increment(ref nCreated);
+            controller.addModel(this);
+        }
+    
+        public override FloatTensor Forward(FloatTensor input)
+        {
+            FloatTensor output = _weights.emptyTensorCopy();
+            
+            var indices = new List<int>();
+
+            foreach (var d in input.Data)
+            {
+                indices.Add((int)d);
+            }
+            
+            if (input.Shape.Length == 1)
+            {
+                output = _weights.IndexSelect(indices, 0);
+            }
+            else
+            {
+                output = _weights.IndexSelect(indices, 0);
+
+                int[] newShape = { input.Shape[0], input.Shape[1], _weights.Shape[1] };
+
+                output = output.View(newShape);
+            }
+
+            return output;
+        }
+        
+        public override int getParameterCount(){return 0;}
+    }
+}

--- a/UnityProject/Assets/OpenMined/Syft/NN/Embedding.cs
+++ b/UnityProject/Assets/OpenMined/Syft/NN/Embedding.cs
@@ -57,7 +57,7 @@ namespace OpenMined.Syft.Layer
 
             return output;
         }
-        
-        public override int getParameterCount(){return 0;}
+
+        public override int getParameterCount(){return _weights.Size;}
     }
 }

--- a/UnityProject/Assets/OpenMined/Syft/NN/Embedding.cs
+++ b/UnityProject/Assets/OpenMined/Syft/NN/Embedding.cs
@@ -31,6 +31,7 @@ namespace OpenMined.Syft.Layer
             controller.addModel(this);
         }
     
+        // TODO this should take a IntTensor
         public override FloatTensor Forward(FloatTensor input)
         {
             FloatTensor output = _weights.emptyTensorCopy();

--- a/UnityProject/Assets/OpenMined/Syft/NN/Embedding.cs.meta
+++ b/UnityProject/Assets/OpenMined/Syft/NN/Embedding.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 765b56e29cd2544c5973d008bd6098c7
+timeCreated: 1514989697
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Description

Embedding Layer -> Pysyft Implementation next and then torch interface. Right now the Embedding layer takes a FloatTensor when it should be taking a IntTensor/LongTensor. This is because the Forward method is overridden and it takes a FloatTensor. Not sure the best way to fix this. If anyone has any ideas, please share. I think otherwise this is fine to merge. There will just be errors if a user tries to pass in none integer values through the FloatTensor.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

  