### PR TITLE
Implement Xavier Weight Initialization and apply to Linear model

### DIFF
--- a/UnityProject/Assets/OpenMined/Network/Controllers/SyftController.cs
+++ b/UnityProject/Assets/OpenMined/Network/Controllers/SyftController.cs
@@ -41,14 +41,25 @@ namespace OpenMined.Network.Controllers
 			get { return shader; }
 		}
 
-		public float[] RandomWeights (int length)
+		public float[] RandomWeights (int length, int inputSize=0)
 		{
-			Random.InitState (1);
-			float[] syn0 = new float[length];
-			for (int i = 0; i < length; i++) {
-				syn0 [i] = 2 * Random.value - 1;
-			}
-			return syn0;
+           float _inputSize = (float)inputSize;
+           float Xavier = (float)Math.Sqrt(1.0F / _inputSize);
+           Random.InitState (1);
+           float[] syn0 = new float[length];
+                for (int i = 0; i < length; i++)
+                {
+                    // Use Xavier Initialization if inputSize is given
+                    if (inputSize>0)
+                    {
+                        syn0 [i] = Random.Range(-Xavier, Xavier);
+                    }
+                    else
+                    {
+                        syn0 [i] = 2 * Random.value - 1;
+                    }
+                }
+		    return syn0;
 		}
 
 		public Model getModel(int index)
@@ -159,7 +170,9 @@ namespace OpenMined.Network.Controllers
 							
 							if (model_type == "linear")
 							{
-								return new Linear(this, int.Parse(msgObj.tensorIndexParams[1]), int.Parse(msgObj.tensorIndexParams[2])).Id.ToString();
+								return new Linear(this, int.Parse(msgObj.tensorIndexParams[1]),
+								int.Parse(msgObj.tensorIndexParams[2]),
+								msgObj.tensorIndexParams[3]).Id.ToString();
 							}
 							else if (model_type == "relu")
 							{

--- a/UnityProject/Assets/OpenMined/Syft/NN/Linear.cs
+++ b/UnityProject/Assets/OpenMined/Syft/NN/Linear.cs
@@ -14,7 +14,7 @@ namespace OpenMined.Syft.Layer
 		private readonly FloatTensor _weights;
 		private FloatTensor _bias;
 		
-		public Linear (SyftController _controller, int input, int output)
+		public Linear (SyftController _controller, int input, int output, string initializer)
 		{
 			init("linear");
 
@@ -24,7 +24,7 @@ namespace OpenMined.Syft.Layer
 			_output = output;
 			
 			int[] weightShape = { input, output };
-			var weights = controller.RandomWeights(input * output);
+            var weights = initializer == "Xavier" ? controller.RandomWeights(input * output, input) : controller.RandomWeights(input * output);
 			_weights = controller.floatTensorFactory.Create(_shape: weightShape, _data: weights, _autograd: true, _keepgrads: true);
 
 			int[] biasShape = {1,output};

--- a/UnityProject/Assets/OpenMined/Syft/NN/Linear.cs
+++ b/UnityProject/Assets/OpenMined/Syft/NN/Linear.cs
@@ -14,7 +14,7 @@ namespace OpenMined.Syft.Layer
 		private readonly FloatTensor _weights;
 		private FloatTensor _bias;
 		
-		public Linear (SyftController _controller, int input, int output, string initializer)
+		public Linear (SyftController _controller, int input, int output, string initializer="Xavier")
 		{
 			init("linear");
 

--- a/notebooks/tests/Test Xavier Initialization.ipynb
+++ b/notebooks/tests/Test Xavier Initialization.ipynb
@@ -1,0 +1,256 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Test Xavier Weight Initialization\n",
+    "First try to solve the model using Xavier weight initialization, then using random weight initialization. This shows using Xavier initialization gives better convergence."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import syft\n",
+    "import syft.nn as nn\n",
+    "\n",
+    "import imp\n",
+    "imp.reload(syft)\n",
+    "imp.reload(syft.nn)\n",
+    "\n",
+    "import numpy as np\n",
+    "from syft import FloatTensor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lin = nn.Linear(250,100, initializer=\"Xavier\")\n",
+    "\n",
+    "model = nn.Sequential([\n",
+    "    lin,\n",
+    "    nn.Tanh(),\n",
+    "    nn.Linear(100,50, initializer=\"Xavier\"),\n",
+    "    nn.Tanh(),\n",
+    "    nn.Linear(50,50, initializer=\"Xavier\"),\n",
+    "    nn.Tanh(),\n",
+    "    nn.Linear(50,200, initializer=\"Xavier\"),\n",
+    "    nn.Sigmoid()\n",
+    "])\n",
+    "np.random.seed(123)\n",
+    "input = FloatTensor(np.random.rand(100,250), autograd=True)\n",
+    "np.random.seed(123)\n",
+    "target = FloatTensor(np.random.randint(0, 1, (100,200)), autograd=True)\n",
+    "np.random.seed(123)\n",
+    "grad = FloatTensor(0.01*np.ones((100,200)), autograd=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Shape of weights (250, 100) - Sqrt of 1/(# inputs) 0.063246\n",
+      "Mean value 0.000010 max value 0.063240 min value -0.063228 \n",
+      "\n",
+      "Shape of weights (100, 50) - Sqrt of 1/(# inputs) 0.100000\n",
+      "Mean value -0.000313 max value 0.099975 min value -0.099972 \n",
+      "\n",
+      "Shape of weights (50, 50) - Sqrt of 1/(# inputs) 0.141421\n",
+      "Mean value -0.001772 max value 0.141386 min value -0.141382 \n",
+      "\n",
+      "Shape of weights (50, 200) - Sqrt of 1/(# inputs) 0.141421\n",
+      "Mean value 0.000441 max value 0.141386 min value -0.141382 \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "for param in model.parameters():\n",
+    "    param_np = param.to_numpy()\n",
+    "    if param_np.shape[0] != 1: # Skip bias weights\n",
+    "        print(\"Shape of weights {} - Sqrt of 1/(# inputs) {:4f}\".format(param_np.shape, np.sqrt(1.0/param_np.shape[0])))\n",
+    "        print(\"Mean value {:2f} max value {:4f} min value {:4f} \\n\".format(np.mean(param_np), np.max(param_np), np.min(param_np)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4975.3066489\n",
+      "2817.99148144\n",
+      "24.6610177812\n",
+      "9.70027632113\n",
+      "7.98010182634\n",
+      "6.89689011504\n",
+      "6.12607268282\n",
+      "5.53921544536\n",
+      "5.07230684267\n",
+      "4.68899085584\n",
+      "4.36674678708\n",
+      "4.09072019851\n",
+      "3.85062905697\n",
+      "3.63908115758\n",
+      "3.45059191323\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i in range(15):\n",
+    "    pred = model(input)\n",
+    "    loss = (pred - target) ** 2\n",
+    "    loss.backward(grad)\n",
+    "    # note: zeroing out gradients has to happen by hand\n",
+    "    for p in model.parameters():\n",
+    "        p -= p.grad()\n",
+    "    print(loss.to_numpy().sum())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "** Without using Xavier Initialization **"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lin = nn.Linear(250,100, initializer=\"x\")\n",
+    "\n",
+    "model = nn.Sequential([\n",
+    "    lin,\n",
+    "    nn.Tanh(),\n",
+    "    nn.Linear(100,50, initializer=\"x\"),\n",
+    "    nn.Tanh(),\n",
+    "    nn.Linear(50,50, initializer=\"x\"),\n",
+    "    nn.Tanh(),\n",
+    "    nn.Linear(50,200, initializer=\"x\"),\n",
+    "    nn.Sigmoid()\n",
+    "])\n",
+    "np.random.seed(123)\n",
+    "input = FloatTensor(np.random.rand(100,250), autograd=True)\n",
+    "np.random.seed(123)\n",
+    "target = FloatTensor(np.random.randint(0, 1, (100,200)), autograd=True)\n",
+    "np.random.seed(123)\n",
+    "grad = FloatTensor(0.01*np.ones((100,200)), autograd=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Shape of weights (250, 100) - Sqrt of 1/(# inputs) 0.063246\n",
+      "Mean value -0.000155 max value 0.999725 min value -0.999917 \n",
+      "\n",
+      "Shape of weights (100, 50) - Sqrt of 1/(# inputs) 0.100000\n",
+      "Mean value 0.003130 max value 0.999725 min value -0.999748 \n",
+      "\n",
+      "Shape of weights (50, 50) - Sqrt of 1/(# inputs) 0.141421\n",
+      "Mean value 0.012528 max value 0.999725 min value -0.999748 \n",
+      "\n",
+      "Shape of weights (50, 200) - Sqrt of 1/(# inputs) 0.141421\n",
+      "Mean value -0.003119 max value 0.999725 min value -0.999748 \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "for param in model.parameters():\n",
+    "    param_np = param.to_numpy()\n",
+    "    if param_np.shape[0] != 1: # Skip bias weights\n",
+    "        print(\"Shape of weights {} - Sqrt of 1/(# inputs) {:4f}\".format(param_np.shape, np.sqrt(1.0/param_np.shape[0])))\n",
+    "        print(\"Mean value {:2f} max value {:4f} min value {:4f} \\n\".format(np.mean(param_np), np.max(param_np), np.min(param_np)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7532.93115248\n",
+      "4328.6242998\n",
+      "1247.12350158\n",
+      "527.160001765\n",
+      "305.659551966\n",
+      "301.321585643\n",
+      "298.716477336\n",
+      "283.256217185\n",
+      "201.75580824\n",
+      "201.581933988\n",
+      "201.448387705\n",
+      "201.341319961\n",
+      "201.252886501\n",
+      "201.178198584\n",
+      "201.114011104\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i in range(15):\n",
+    "    pred = model(input)\n",
+    "    loss = (pred - target) ** 2\n",
+    "    loss.backward(grad)\n",
+    "    # note: zeroing out gradients has to happen by hand\n",
+    "    for p in model.parameters():\n",
+    "        p -= p.grad()\n",
+    "    print(loss.to_numpy().sum())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
# Description
Implemented Xavier Weight Initialization and applied it to the Linear model. 

Xavier weight initialization means initializing the parameter weights on a uniform distribution within the range of: `-sqrt(1/num_inputs), sqrt(1/num_inputs)` which has been shown to improve model stability/convergence. 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Added tests for an existing feature

# How Has This Been Tested?
I added a notebook that tests the implementation and shows the model trains faster using Xavier weight initialization.
# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
