### PR TITLE
Fixed issue with functions that call Reduce, added Var, Std, Norm and Split.

### DIFF
--- a/UnityProject/Assets/OpenMined.Tests/Editor/FloatTensor/FloatTensorTest.cs
+++ b/UnityProject/Assets/OpenMined.Tests/Editor/FloatTensor/FloatTensorTest.cs
@@ -1539,7 +1539,7 @@ namespace OpenMined.Tests.Editor.FloatTensor
             Assert.AreEqual(result.Shape.Length, 1);
             Assert.AreEqual(result.Shape[0], 1);
             Assert.AreEqual(result.Size, 1);
-            Assert.AreEqual(result[0], 3.0);
+            Assert.AreEqual(result[0], 21.0);
 
             result = tensor.Norm(0,p:1);
 
@@ -1547,9 +1547,9 @@ namespace OpenMined.Tests.Editor.FloatTensor
             Assert.AreEqual(result.Shape.Length, 1);
             Assert.AreEqual(result.Shape[0], 3);
             Assert.AreEqual(result.Size, 3);
-            Assert.AreEqual(result[0], 3.0);
-            Assert.AreEqual(result[1], -3.0);
-            Assert.AreEqual(result[2], 3.0);
+            Assert.AreEqual(result[0], 5.0);
+            Assert.AreEqual(result[1], 7.0);
+            Assert.AreEqual(result[2], 9.0);
 
             result = tensor.Norm(1,p:1);
 
@@ -1557,8 +1557,8 @@ namespace OpenMined.Tests.Editor.FloatTensor
             Assert.AreEqual(result.Shape.Length, 1);
             Assert.AreEqual(result.Shape[0], 2);
             Assert.AreEqual(result.Size, 2);
-            Assert.AreEqual(result[0], -2.0);
-            Assert.AreEqual(result[1], 5.0);
+            Assert.AreEqual(result[0], 6.0);
+            Assert.AreEqual(result[1], 15.0);
 
             result = tensor.Norm(keepdim:true);
 
@@ -1588,44 +1588,6 @@ namespace OpenMined.Tests.Editor.FloatTensor
             Assert.AreEqual(result.Size, 2);
             Assert.AreEqual(result[0], 3.74165739f, 1e-3);
             Assert.AreEqual(result[1], 8.77496439f, 1e-3);
-
-            float[] data2 = new float[]
-            {
-                1, 2, 3,
-                4, 5, 6
-            };
-
-            int[] shape2 = new int[] {2, 3};
-            var tensor2 = ctrl.floatTensorFactory.Create(_data: data2, _shape: shape2);
-
-            Console.WriteLine("tensor2 {0}", string.Join(", ", tensor2.Data));
-
-            result = tensor2.Norm(p:3);
-
-            Console.WriteLine("tensor2.Norm(p:3) {0}", string.Join(", ", result.Data));
-            Assert.AreEqual(result.Shape.Length, 1);
-            Assert.AreEqual(result.Shape[0], 1);
-            Assert.AreEqual(result.Size, 1);
-            Assert.AreEqual(result[0], 7.6116626110202441f, 1e-3);
-
-            result = tensor2.Norm(0,p:3);
-
-            Console.WriteLine("tensor2.Norm(0,p:3) {0}", string.Join(", ", result.Data));
-            Assert.AreEqual(result.Shape.Length, 1);
-            Assert.AreEqual(result.Shape[0], 3);
-            Assert.AreEqual(result.Size, 3);
-            Assert.AreEqual(result[0], 4.02072576f, 1e-3);
-            Assert.AreEqual(result[1], 5.10446872f, 1e-3);
-            Assert.AreEqual(result[2], 6.24025147f, 1e-3);
-
-            result = tensor2.Norm(1,p:3);
-
-            Console.WriteLine("tensor2.Norm(1,p:3) {0}", string.Join(", ", result.Data));
-            Assert.AreEqual(result.Shape.Length, 1);
-            Assert.AreEqual(result.Shape[0], 2);
-            Assert.AreEqual(result.Size, 2);
-            Assert.AreEqual(result[0], 3.30192725f, 1e-3);
-            Assert.AreEqual(result[1], 7.39863622f, 1e-3);
         }
 
         [Test]
@@ -2422,10 +2384,10 @@ namespace OpenMined.Tests.Editor.FloatTensor
             int[] expectedShape2 = {2, 1};
 
             
-            for(int j = 0; j < splits[0].Shape.Length; j++)
+            for(int i = 0; i < splits[0].Shape.Length; i++)
             {
-                Assert.AreEqual(expectedShape1[j], splits[0].Shape[j]);
-                Assert.AreEqual(expectedShape2[j], splits[1].Shape[j]);
+                Assert.AreEqual(expectedShape1[i], splits[0].Shape[i]);
+                Assert.AreEqual(expectedShape2[i], splits[1].Shape[i]);
             }
             
             float[] splitData1 = {1, 2, 3, 5, 6, 7};
@@ -2462,9 +2424,9 @@ namespace OpenMined.Tests.Editor.FloatTensor
             Assert.AreEqual(1, splits.Length);
             Assert.AreEqual(2, splits[0].Shape.Length);
 
-            for(int j = 0; j < splits[0].Shape.Length; j++)
+            for(int i = 0; i < splits[0].Shape.Length; i++)
             {
-                Assert.AreEqual(shape[j], splits[0].Shape[j]);
+                Assert.AreEqual(shape[i], splits[0].Shape[i]);
             }
 
             for(int i = 0; i < shape[0]; i++){
@@ -2498,11 +2460,11 @@ namespace OpenMined.Tests.Editor.FloatTensor
             int[] expectedShape3 = {2, 2};
 
             
-            for(int j = 0; j < splits[0].Shape.Length; j++)
+            for(int i = 0; i < splits[0].Shape.Length; i++)
             {
-                Assert.AreEqual(expectedShape1[j], splits[0].Shape[j]);
-                Assert.AreEqual(expectedShape2[j], splits[1].Shape[j]);
-                Assert.AreEqual(expectedShape3[j], splits[2].Shape[j]);
+                Assert.AreEqual(expectedShape1[i], splits[0].Shape[i]);
+                Assert.AreEqual(expectedShape2[i], splits[1].Shape[i]);
+                Assert.AreEqual(expectedShape3[i], splits[2].Shape[i]);
             }
 
             float[] splitData1 = {1, 4};

--- a/UnityProject/Assets/OpenMined.Tests/Editor/FloatTensor/FloatTensorTest.cs
+++ b/UnityProject/Assets/OpenMined.Tests/Editor/FloatTensor/FloatTensorTest.cs
@@ -1105,7 +1105,15 @@ namespace OpenMined.Tests.Editor.FloatTensor
             Assert.AreEqual(result[0], 3.0);
             Assert.AreEqual(result[1], 6.0);
 
-            /*result = tensor.Max(0, true);
+            result = tensor.Max(keepdim:true);
+
+            Console.WriteLine("tensor.Max(keepdim:true) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 1);
+            Assert.AreEqual(result.Size, 1);
+            Assert.AreEqual(result[0], 6.0);
+
+            result = tensor.Max(0, true);
 
             Console.WriteLine("tensor.Max(0, true) {0}", string.Join(", ", result.Data));
             Assert.AreEqual(result.Shape.Length, 2);
@@ -1114,7 +1122,17 @@ namespace OpenMined.Tests.Editor.FloatTensor
             Assert.AreEqual(result.Size, 3);
             Assert.AreEqual(result[0], 4.0);
             Assert.AreEqual(result[1], 5.0);
-            Assert.AreEqual(result[2], 6.0);*/
+            Assert.AreEqual(result[2], 6.0);
+
+            result = tensor.Max(1, true);
+
+            Console.WriteLine("tensor.Max(1, true) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 2);
+            Assert.AreEqual(result.Shape[0], 2);
+            Assert.AreEqual(result.Shape[1], 1);
+            Assert.AreEqual(result.Size, 2);
+            Assert.AreEqual(result[0], 3.0);
+            Assert.AreEqual(result[1], 6.0);
         }
 
         [Test]
@@ -1158,7 +1176,15 @@ namespace OpenMined.Tests.Editor.FloatTensor
             Assert.AreEqual(result[0], 6.0 / 3.0);
             Assert.AreEqual(result[1], 15.0 / 3.0);
 
-            /*result = tensor.Mean(0, true);
+            result = tensor.Mean(keepdim:true);
+
+            Console.WriteLine("tensor.Mean(keepdim:true) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 1);
+            Assert.AreEqual(result.Size, 1);
+            Assert.AreEqual(result[0], 21.0 / 6.0);
+
+            result = tensor.Mean(0, true);
 
             Console.WriteLine("tensor.Mean(0, true) {0}", string.Join(", ", result.Data));
             Assert.AreEqual(result.Shape.Length, 2);
@@ -1167,7 +1193,17 @@ namespace OpenMined.Tests.Editor.FloatTensor
             Assert.AreEqual(result.Size, 3);
             Assert.AreEqual(result[0], 5.0 / 2.0);
             Assert.AreEqual(result[1], 7.0 / 2.0);
-            Assert.AreEqual(result[2], 9.0 / 2.0);*/
+            Assert.AreEqual(result[2], 9.0 / 2.0);
+
+            result = tensor.Mean(1, true);
+
+            Console.WriteLine("tensor.Mean(1, true) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 2);
+            Assert.AreEqual(result.Shape[0], 2);
+            Assert.AreEqual(result.Shape[1], 1);
+            Assert.AreEqual(result.Size, 2);
+            Assert.AreEqual(result[0], 6.0 / 3.0);
+            Assert.AreEqual(result[1], 15.0 / 3.0);
         }
 
         [Test]
@@ -1211,7 +1247,15 @@ namespace OpenMined.Tests.Editor.FloatTensor
             Assert.AreEqual(result[0], 1.0);
             Assert.AreEqual(result[1], 4.0);
 
-            /*result = tensor.Min(0, true);
+            result = tensor.Min(keepdim:true);
+
+            Console.WriteLine("tensor.Min(keepdim:true) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 1);
+            Assert.AreEqual(result.Size, 1);
+            Assert.AreEqual(result[0], 1.0);
+
+            result = tensor.Min(0, true);
 
             Console.WriteLine("tensor.Min(0, true) {0}", string.Join(", ", result.Data));
             Assert.AreEqual(result.Shape.Length, 2);
@@ -1220,7 +1264,17 @@ namespace OpenMined.Tests.Editor.FloatTensor
             Assert.AreEqual(result.Size, 3);
             Assert.AreEqual(result[0], 1.0);
             Assert.AreEqual(result[1], 2.0);
-            Assert.AreEqual(result[2], 3.0);*/
+            Assert.AreEqual(result[2], 3.0);
+
+            result = tensor.Min(1, true);
+
+            Console.WriteLine("tensor.Min(1, true) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 2);
+            Assert.AreEqual(result.Shape[0], 2);
+            Assert.AreEqual(result.Shape[1], 1);
+            Assert.AreEqual(result.Size, 2);
+            Assert.AreEqual(result[0], 1.0);
+            Assert.AreEqual(result[1], 4.0);
         }
 
         [Test]
@@ -1439,6 +1493,142 @@ namespace OpenMined.Tests.Editor.FloatTensor
         }
 
         [Test]
+        public void Norm()
+        {
+            float[] data = new float[]
+            {
+                -1, 2, -3,
+                4, -5, 6
+            };
+
+            int[] shape = new int[] {2, 3};
+            var tensor = ctrl.floatTensorFactory.Create(_data: data, _shape: shape);
+
+            Console.WriteLine("tensor {0}", string.Join(", ", tensor.Data));
+
+            Syft.Tensor.FloatTensor result = tensor.Norm();
+
+            Console.WriteLine("tensor.Norm() {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 1);
+            Assert.AreEqual(result.Size, 1);
+            Assert.AreEqual(result[0], 9.5393920141694561f, 1e-3);
+
+            result = tensor.Norm(0);
+
+            Console.WriteLine("tensor.Norm(0) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 3);
+            Assert.AreEqual(result.Size, 3);
+            Assert.AreEqual(result[0], 4.12310563f, 1e-3);
+            Assert.AreEqual(result[1], 5.38516481f, 1e-3);
+            Assert.AreEqual(result[2], 6.70820393, 1e-3);
+
+            result = tensor.Norm(1);
+
+            Console.WriteLine("tensor.Norm(1) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 2);
+            Assert.AreEqual(result.Size, 2);
+            Assert.AreEqual(result[0], 3.74165739f, 1e-3);
+            Assert.AreEqual(result[1], 8.77496439f, 1e-3);
+
+            result = tensor.Norm(p:1);
+
+            Console.WriteLine("tensor.Norm(p:1) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 1);
+            Assert.AreEqual(result.Size, 1);
+            Assert.AreEqual(result[0], 3.0);
+
+            result = tensor.Norm(0,p:1);
+
+            Console.WriteLine("tensor.Norm(0,p:1) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 3);
+            Assert.AreEqual(result.Size, 3);
+            Assert.AreEqual(result[0], 3.0);
+            Assert.AreEqual(result[1], -3.0);
+            Assert.AreEqual(result[2], 3.0);
+
+            result = tensor.Norm(1,p:1);
+
+            Console.WriteLine("tensor.Norm(1,p:1) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 2);
+            Assert.AreEqual(result.Size, 2);
+            Assert.AreEqual(result[0], -2.0);
+            Assert.AreEqual(result[1], 5.0);
+
+            result = tensor.Norm(keepdim:true);
+
+            Console.WriteLine("tensor.Norm(keepdim:true) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 1);
+            Assert.AreEqual(result.Size, 1);
+            Assert.AreEqual(result[0], 9.5393920141694561f, 1e-3);
+
+            result = tensor.Norm(0, keepdim:true);
+
+            Console.WriteLine("tensor.Norm(0, keepdim:true) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 2);
+            Assert.AreEqual(result.Shape[0], 1);
+            Assert.AreEqual(result.Shape[1], 3);
+            Assert.AreEqual(result.Size, 3);
+            Assert.AreEqual(result[0], 4.12310563f, 1e-3);
+            Assert.AreEqual(result[1], 5.38516481f, 1e-3);
+            Assert.AreEqual(result[2], 6.70820393, 1e-3);
+
+            result = tensor.Norm(1, keepdim:true);
+
+            Console.WriteLine("tensor.Norm(1, keepdim:true) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 2);
+            Assert.AreEqual(result.Shape[0], 2);
+            Assert.AreEqual(result.Shape[1], 1);
+            Assert.AreEqual(result.Size, 2);
+            Assert.AreEqual(result[0], 3.74165739f, 1e-3);
+            Assert.AreEqual(result[1], 8.77496439f, 1e-3);
+
+            float[] data2 = new float[]
+            {
+                1, 2, 3,
+                4, 5, 6
+            };
+
+            int[] shape2 = new int[] {2, 3};
+            var tensor2 = ctrl.floatTensorFactory.Create(_data: data2, _shape: shape2);
+
+            Console.WriteLine("tensor2 {0}", string.Join(", ", tensor2.Data));
+
+            result = tensor2.Norm(p:3);
+
+            Console.WriteLine("tensor2.Norm(p:3) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 1);
+            Assert.AreEqual(result.Size, 1);
+            Assert.AreEqual(result[0], 7.6116626110202441f, 1e-3);
+
+            result = tensor2.Norm(0,p:3);
+
+            Console.WriteLine("tensor2.Norm(0,p:3) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 3);
+            Assert.AreEqual(result.Size, 3);
+            Assert.AreEqual(result[0], 4.02072576f, 1e-3);
+            Assert.AreEqual(result[1], 5.10446872f, 1e-3);
+            Assert.AreEqual(result[2], 6.24025147f, 1e-3);
+
+            result = tensor2.Norm(1,p:3);
+
+            Console.WriteLine("tensor2.Norm(1,p:3) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 2);
+            Assert.AreEqual(result.Size, 2);
+            Assert.AreEqual(result[0], 3.30192725f, 1e-3);
+            Assert.AreEqual(result[1], 7.39863622f, 1e-3);
+        }
+
+        [Test]
         public void Prod()
         {
             float[] data = new float[]
@@ -1479,7 +1669,15 @@ namespace OpenMined.Tests.Editor.FloatTensor
             Assert.AreEqual(result[0], 6.0);
             Assert.AreEqual(result[1], 120.0);
 
-         /*   result = tensor.Prod(0, true);
+            result = tensor.Prod(keepdim:true);
+
+            Console.WriteLine("tensor.Prod(keepdim:true) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 1);
+            Assert.AreEqual(result.Size, 1);
+            Assert.AreEqual(result[0], 720.0);
+
+            result = tensor.Prod(0, true);
 
             Console.WriteLine("tensor.Prod(0, true) {0}", string.Join(", ", result.Data));
             Assert.AreEqual(result.Shape.Length, 2);
@@ -1488,7 +1686,17 @@ namespace OpenMined.Tests.Editor.FloatTensor
             Assert.AreEqual(result.Size, 3);
             Assert.AreEqual(result[0], 4.0);
             Assert.AreEqual(result[1], 10.0);
-            Assert.AreEqual(result[2], 18.0);*/
+            Assert.AreEqual(result[2], 18.0);
+
+            result = tensor.Prod(1, true);
+
+            Console.WriteLine("tensor.Prod(1, true) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 2);
+            Assert.AreEqual(result.Shape[0], 2);
+            Assert.AreEqual(result.Shape[1], 1);
+            Assert.AreEqual(result.Size, 2);
+            Assert.AreEqual(result[0], 6.0);
+            Assert.AreEqual(result[1], 120.0);
         }
 
         [Test]
@@ -1998,6 +2206,329 @@ namespace OpenMined.Tests.Editor.FloatTensor
         }
 
         [Test]
+        public void SplitSameBySize()
+        {
+            float[] data = {1, 2, 3, 4, 5, 6, 7, 8};
+            int[] shape = {2, 4};
+
+            var tensor = ctrl.floatTensorFactory.Create(_data: data, _shape: shape);
+
+            var splits = tensor.Split(1);
+            Assert.AreEqual(2, splits.Length);
+
+            for(int i = 0; i < splits.Length; i++)
+            {
+                Assert.AreEqual(2, splits[i].Shape.Length);
+            }
+
+            int[] expectedShape = {1, 4};
+
+            for(int i = 0; i < splits.Length; i++){
+                for(int j = 0; j < splits[0].Shape.Length; j++)
+                {
+                    Assert.AreEqual(expectedShape[j], splits[i].Shape[j]);
+                }
+            }
+
+            float[] splitData1 = {1, 2, 3, 4};
+            float[] splitData2 = {5, 6, 7, 8};
+
+            var expectedTensor1 = ctrl.floatTensorFactory.Create(_data: splitData1, _shape: expectedShape);
+            var expectedTensor2 =   ctrl.floatTensorFactory.Create(_data: splitData2, _shape: expectedShape);
+
+            for(int i = 0; i < expectedShape[0]; i++){
+                for(int j = 0; j < expectedShape[1]; j++)
+                {   
+                    Assert.AreEqual(expectedTensor1[i, j], splits[0][i, j]);
+                    Assert.AreEqual(expectedTensor2[i, j], splits[1][i, j]);
+                }
+
+            }
+
+            var splits2 = tensor.Split(2, dim:1);
+            Assert.AreEqual(2, splits2.Length);
+
+            for(int i = 0; i < splits2.Length; i++)
+            {
+                Assert.AreEqual(2, splits2[i].Shape.Length);
+            }
+
+            int[] expectedShape2 = {2, 2};
+
+            for(int i = 0; i < splits2.Length; i++)
+            {
+                for(int j = 0; j < splits2[0].Shape.Length; j++)
+                {
+                    Assert.AreEqual(expectedShape2[j], splits2[i].Shape[j]);
+                }
+            }
+
+            float[] splitData3 = {1, 2, 5, 6};
+            float[] splitData4 = {3, 4, 7, 8};
+            
+            var expectedTensor3 = ctrl.floatTensorFactory.Create(_data: splitData3, _shape: expectedShape2);
+            var expectedTensor4 = ctrl.floatTensorFactory.Create(_data: splitData4, _shape: expectedShape2);
+
+            for(int i = 0; i < expectedShape2[0]; i++){
+                for(int j = 0; j < expectedShape2[1]; j++)
+                {   
+                    Assert.AreEqual(expectedTensor3[i, j], splits2[0][i, j]);
+                    Assert.AreEqual(expectedTensor4[i, j], splits2[1][i, j]);
+                }
+            }
+        }
+
+        [Test]
+        public void SplitDiffBySize()
+        {
+            float[] data = {1, 2, 3, 4, 5, 6, 7, 8};
+            int[] shape = {2, 4};
+
+            var tensor = ctrl.floatTensorFactory.Create(_data: data, _shape: shape);
+            
+            var splits = tensor.Split(3, 1);
+            Assert.AreEqual(2, splits.Length);
+
+            for(int i = 0; i < splits.Length; i++)
+            {
+                Assert.AreEqual(2, splits[i].Shape.Length);
+            }
+
+            int[] expectedShape1 = {2, 3};
+            int[] expectedShape2 = {2, 1};
+
+            
+            for(int j = 0; j < splits[0].Shape.Length; j++)
+            {
+                Assert.AreEqual(expectedShape1[j], splits[0].Shape[j]);
+                Assert.AreEqual(expectedShape2[j], splits[1].Shape[j]);
+            }
+            
+            float[] splitData1 = {1, 2, 3, 5, 6, 7};
+            float[] splitData2 = {4, 8};
+
+            var expectedTensor1 = ctrl.floatTensorFactory.Create(_data: splitData1, _shape: expectedShape1);
+            var expectedTensor2 =  ctrl.floatTensorFactory.Create(_data: splitData2, _shape: expectedShape2);
+
+            for(int i = 0; i < expectedShape1[0]; i++){
+                for(int j = 0; j < expectedShape1[1]; j++)
+                {   
+                    Assert.AreEqual(expectedTensor1[i, j], splits[0][i, j]);
+                }
+            }
+
+            for(int i = 0; i < expectedShape2[0]; i++){
+                for(int j = 0; j < expectedShape2[1]; j++)
+                {   
+                    Assert.AreEqual(expectedTensor2[i, j], splits[1][i, j]);
+                }
+            }
+        }
+
+        [Test]
+        public void SplitSameBySections()
+        {
+            float[] data = {1, 2, 3, 4, 5, 6, 7, 8};
+            int[] shape = {2, 4};
+
+            var tensor = ctrl.floatTensorFactory.Create(_data: data, _shape: shape);
+
+            int[] sections = {1,1};
+            var splits = tensor.Split(sections);
+            Assert.AreEqual(2, splits.Length);
+
+            for(int i = 0; i < splits.Length; i++)
+            {
+                Assert.AreEqual(2, splits[i].Shape.Length);
+            }
+
+            int[] expectedShape = {1, 4};
+
+            for(int i = 0; i < splits.Length; i++){
+                for(int j = 0; j < splits[0].Shape.Length; j++)
+                {
+                    Assert.AreEqual(expectedShape[j], splits[i].Shape[j]);
+                }
+            }
+
+            float[] splitData1 = {1, 2, 3, 4};
+            float[] splitData2 = {5, 6, 7, 8};
+
+            var expectedTensor1 = ctrl.floatTensorFactory.Create(_data: splitData1, _shape: expectedShape);
+            var expectedTensor2 =   ctrl.floatTensorFactory.Create(_data: splitData2, _shape: expectedShape);
+
+            for(int i = 0; i < expectedShape[0]; i++){
+                for(int j = 0; j < expectedShape[1]; j++)
+                {   
+                    Assert.AreEqual(expectedTensor1[i, j], splits[0][i, j]);
+                    Assert.AreEqual(expectedTensor2[i, j], splits[1][i, j]);
+                }
+
+            }
+
+            int[] sections2 = {2,2};
+            var splits2 = tensor.Split(sections2, dim:1);
+            Assert.AreEqual(2, splits2.Length);
+
+            for(int i = 0; i < splits2.Length; i++)
+            {
+                Assert.AreEqual(2, splits2[i].Shape.Length);
+            }
+
+            int[] expectedShape2 = {2, 2};
+
+            for(int i = 0; i < splits2.Length; i++)
+            {
+                for(int j = 0; j < splits2[0].Shape.Length; j++)
+                {
+                    Assert.AreEqual(expectedShape2[j], splits2[i].Shape[j]);
+                }
+            }
+
+            float[] splitData3 = {1, 2, 5, 6};
+            float[] splitData4 = {3, 4, 7, 8};
+            
+            var expectedTensor3 = ctrl.floatTensorFactory.Create(_data: splitData3, _shape: expectedShape2);
+            var expectedTensor4 = ctrl.floatTensorFactory.Create(_data: splitData4, _shape: expectedShape2);
+
+            for(int i = 0; i < expectedShape2[0]; i++){
+                for(int j = 0; j < expectedShape2[1]; j++)
+                {   
+                    Assert.AreEqual(expectedTensor3[i, j], splits2[0][i, j]);
+                    Assert.AreEqual(expectedTensor4[i, j], splits2[1][i, j]);
+                }
+            }
+
+        }
+
+        [Test]
+        public void SplitDiffBySections()
+        {
+            float[] data = {1, 2, 3, 4, 5, 6, 7, 8};
+            int[] shape = {2, 4};
+
+            var tensor = ctrl.floatTensorFactory.Create(_data: data, _shape: shape);
+
+            int[] sections = {3, 1};
+            var splits = tensor.Split(sections, 1);
+            Assert.AreEqual(2, splits.Length);
+
+            for(int i = 0; i < splits.Length; i++)
+            {
+                Assert.AreEqual(2, splits[i].Shape.Length);
+            }
+
+            int[] expectedShape1 = {2, 3};
+            int[] expectedShape2 = {2, 1};
+
+            
+            for(int j = 0; j < splits[0].Shape.Length; j++)
+            {
+                Assert.AreEqual(expectedShape1[j], splits[0].Shape[j]);
+                Assert.AreEqual(expectedShape2[j], splits[1].Shape[j]);
+            }
+            
+            float[] splitData1 = {1, 2, 3, 5, 6, 7};
+            float[] splitData2 = {4, 8};
+
+            var expectedTensor1 = ctrl.floatTensorFactory.Create(_data: splitData1, _shape: expectedShape1);
+            var expectedTensor2 =  ctrl.floatTensorFactory.Create(_data: splitData2, _shape: expectedShape2);
+
+            for(int i = 0; i < expectedShape1[0]; i++){
+                for(int j = 0; j < expectedShape1[1]; j++)
+                {   
+                    Assert.AreEqual(expectedTensor1[i, j], splits[0][i, j]);
+                }
+            }
+
+            for(int i = 0; i < expectedShape2[0]; i++){
+                for(int j = 0; j < expectedShape2[1]; j++)
+                {   
+                    Assert.AreEqual(expectedTensor2[i, j], splits[1][i, j]);
+                }
+            }
+        }
+
+        [Test]
+        public void SplitSizeLargerThanDim()
+        {
+            float[] data = {1, 2, 3, 4};
+            int[] shape = {1, 4};
+
+            var tensor = ctrl.floatTensorFactory.Create(_data: data, _shape: shape);
+            
+            var splits = tensor.Split(3);
+
+            Assert.AreEqual(1, splits.Length);
+            Assert.AreEqual(2, splits[0].Shape.Length);
+
+            for(int j = 0; j < splits[0].Shape.Length; j++)
+            {
+                Assert.AreEqual(shape[j], splits[0].Shape[j]);
+            }
+
+            for(int i = 0; i < shape[0]; i++){
+                for(int j = 0; j < shape[1]; j++)
+                {   
+                    Assert.AreEqual(tensor[i, j], splits[0][i, j]);
+                }
+            }
+        }
+
+        [Test]
+        public void SplitSectionsWithZero()
+        {
+            float[] data = {1, 2, 3, 4, 5, 6};
+            int[] shape = {2, 3};
+
+            var tensor = ctrl.floatTensorFactory.Create(_data: data, _shape: shape);
+            
+            int[] sections = {1,0,2};
+            var splits = tensor.Split(sections, 1);
+
+            Assert.AreEqual(3, splits.Length);
+
+            for(int i = 0; i < splits.Length; i++)
+            {
+                Assert.AreEqual(2, splits[i].Shape.Length);
+            }
+
+            int[] expectedShape1 = {2, 1};
+            int[] expectedShape2 = {2, 0};
+            int[] expectedShape3 = {2, 2};
+
+            
+            for(int j = 0; j < splits[0].Shape.Length; j++)
+            {
+                Assert.AreEqual(expectedShape1[j], splits[0].Shape[j]);
+                Assert.AreEqual(expectedShape2[j], splits[1].Shape[j]);
+                Assert.AreEqual(expectedShape3[j], splits[2].Shape[j]);
+            }
+
+            float[] splitData1 = {1, 4};
+            float[] splitData3 = {2, 3, 5, 6};
+
+            var expectedTensor1 = ctrl.floatTensorFactory.Create(_data: splitData1, _shape: expectedShape1);
+            var expectedTensor3 =   ctrl.floatTensorFactory.Create(_data: splitData3, _shape: expectedShape3);
+
+            for(int i = 0; i < expectedShape1[0]; i++){
+                for(int j = 0; j < expectedShape1[1]; j++)
+                {   
+                    Assert.AreEqual(expectedTensor1[i, j], splits[0][i, j]);
+                }
+            }
+
+            Assert.AreEqual(0, splits[1].Data.Length);
+
+            for(int i = 0; i < expectedShape3[0]; i++){
+                for(int j = 0; j < expectedShape3[1]; j++)
+                {   
+                    Assert.AreEqual(expectedTensor3[i, j], splits[2][i, j]);
+                }
+            }
+        }
+
+        [Test]
         public void Squeeze()
         {
             float[] data1 = {1, 2, 3, 4};
@@ -2082,6 +2613,103 @@ namespace OpenMined.Tests.Editor.FloatTensor
             }
         }
 
+        [Test]
+        public void Std()
+        {
+            float[] data = new float[]
+            {
+                1, 2, 3,
+                1, 4, 9
+            };
+
+            int[] shape = new int[] {2, 3};
+            var tensor = ctrl.floatTensorFactory.Create(_data: data, _shape: shape);
+
+            Console.WriteLine("tensor {0}", string.Join(", ", tensor.Data));
+
+            Syft.Tensor.FloatTensor result = tensor.Std();
+
+            Console.WriteLine("tensor.Std() {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 1);
+            Assert.AreEqual(result.Size, 1);
+            Assert.AreEqual(result[0], 3.011090610836324f, 1e-3);
+
+            result = tensor.Std(0);
+
+            Console.WriteLine("tensor.Std(0) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 3);
+            Assert.AreEqual(result.Size, 3);
+            Assert.AreEqual(result[0], 0.0);
+            Assert.AreEqual(result[1], 1.41421356f, 1e-3);
+            Assert.AreEqual(result[2], 4.24264069f, 1e-3);
+
+            result = tensor.Std(1);
+
+            Console.WriteLine("tensor.Std(1) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 2);
+            Assert.AreEqual(result.Size, 2);
+            Assert.AreEqual(result[0], 1.0);
+            Assert.AreEqual(result[1], 4.04145188f, 1e-3);
+
+            result = tensor.Std(unbiased:false);
+
+            Console.WriteLine("tensor.Std(unbiased:false) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 1);
+            Assert.AreEqual(result.Size, 1);
+            Assert.AreEqual(result[0], 2.7487370837451071f, 1e-3);
+
+            result = tensor.Std(0, unbiased:false);
+
+            Console.WriteLine("tensor.Std(0, unbiased:false) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 3);
+            Assert.AreEqual(result.Size, 3);
+            Assert.AreEqual(result[0], 0.0);
+            Assert.AreEqual(result[1], 1.0);
+            Assert.AreEqual(result[2], 3.0);
+
+            result = tensor.Std(1, unbiased:false);
+
+            Console.WriteLine("tensor.Std(1, unbiased:false) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 2);
+            Assert.AreEqual(result.Size, 2);
+            Assert.AreEqual(result[0], 0.81649658f, 1e-3);
+            Assert.AreEqual(result[1], 3.29983165f, 1e-3);
+
+            result = tensor.Std(keepdim:true);
+
+            Console.WriteLine("tensor.Std(keepdim:true) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 1);
+            Assert.AreEqual(result.Size, 1);
+            Assert.AreEqual(result[0], 3.011090610836324f, 1e-3);
+
+            result = tensor.Std(0,keepdim:true);
+
+            Console.WriteLine("tensor.Std(0, keepdim:true) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 2);
+            Assert.AreEqual(result.Shape[0], 1);
+            Assert.AreEqual(result.Shape[1], 3);
+            Assert.AreEqual(result.Size, 3);
+            Assert.AreEqual(result[0], 0.0);
+            Assert.AreEqual(result[1], 1.41421356f, 1e-3);
+            Assert.AreEqual(result[2], 4.24264069f, 1e-3);
+
+            result = tensor.Std(1,keepdim:true);
+
+            Console.WriteLine("tensor.Std(1, keepdim:true) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 2);
+            Assert.AreEqual(result.Shape[0], 2);
+            Assert.AreEqual(result.Shape[1], 1);
+            Assert.AreEqual(result.Size, 2);
+            Assert.AreEqual(result[0], 1.0);
+            Assert.AreEqual(result[1], 4.04145188f, 1e-3);
+        }
 
         [Test]
         public void SubtractElementwise()
@@ -2301,7 +2929,15 @@ namespace OpenMined.Tests.Editor.FloatTensor
             Assert.AreEqual(result[0], 6.0);
             Assert.AreEqual(result[1], 15.0);
 
-            /*result = tensor.Sum(0, true);
+            result = tensor.Sum(keepdim:true);
+
+            Console.WriteLine("tensor.Sum() {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 1);
+            Assert.AreEqual(result.Size, 1);
+            Assert.AreEqual(result[0], 21.0);
+
+            result = tensor.Sum(0, true);
 
             Console.WriteLine("tensor.Sum(0, true) {0}", string.Join(", ", result.Data));
             Assert.AreEqual(result.Shape.Length, 2);
@@ -2310,7 +2946,17 @@ namespace OpenMined.Tests.Editor.FloatTensor
             Assert.AreEqual(result.Size, 3);
             Assert.AreEqual(result[0], 5.0);
             Assert.AreEqual(result[1], 7.0);
-            Assert.AreEqual(result[2], 9.0);*/
+            Assert.AreEqual(result[2], 9.0);
+
+            result = tensor.Sum(1, true);
+
+            Console.WriteLine("tensor.Sum(1) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 2);
+            Assert.AreEqual(result.Shape[0], 2);
+            Assert.AreEqual(result.Shape[1], 1);
+            Assert.AreEqual(result.Size, 2);
+            Assert.AreEqual(result[0], 6.0);
+            Assert.AreEqual(result[1], 15.0);
         }
 
         [Test]
@@ -2625,6 +3271,103 @@ namespace OpenMined.Tests.Editor.FloatTensor
             Assert.AreEqual(3, newTensor.Shape.Length);
         }
 
+        [Test]
+        public void Var()
+        {
+            float[] data = new float[]
+            {
+                1, 2, 3,
+                1, 4, 9
+            };
+
+            int[] shape = new int[] {2, 3};
+            var tensor = ctrl.floatTensorFactory.Create(_data: data, _shape: shape);
+
+            Console.WriteLine("tensor {0}", string.Join(", ", tensor.Data));
+
+            Syft.Tensor.FloatTensor result = tensor.Var();
+
+            Console.WriteLine("tensor.Var() {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 1);
+            Assert.AreEqual(result.Size, 1);
+            Assert.AreEqual(result[0], 9.0666666666666664f, 1e-3);
+
+            result = tensor.Var(0);
+
+            Console.WriteLine("tensor.Var(0) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 3);
+            Assert.AreEqual(result.Size, 3);
+            Assert.AreEqual(result[0], 0.0);
+            Assert.AreEqual(result[1], 2.0);
+            Assert.AreEqual(result[2], 18.0);
+
+            result = tensor.Var(1);
+
+            Console.WriteLine("tensor.Var(1) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 2);
+            Assert.AreEqual(result.Size, 2);
+            Assert.AreEqual(result[0], 1.0);
+            Assert.AreEqual(result[1], 16.33333333f, 1e-3);
+
+            result = tensor.Var(unbiased:false);
+
+            Console.WriteLine("tensor.Var(unbiased:false) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 1);
+            Assert.AreEqual(result.Size, 1);
+            Assert.AreEqual(result[0], 7.5555555555555545f, 1e-3);
+
+            result = tensor.Var(0, unbiased:false);
+
+            Console.WriteLine("tensor.Var(0, unbiased:false) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 3);
+            Assert.AreEqual(result.Size, 3);
+            Assert.AreEqual(result[0], 0.0);
+            Assert.AreEqual(result[1], 1.0);
+            Assert.AreEqual(result[2], 9.0);
+
+            result = tensor.Var(1, unbiased:false);
+
+            Console.WriteLine("tensor.Var(1, unbiased:false) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 2);
+            Assert.AreEqual(result.Size, 2);
+            Assert.AreEqual(result[0], 0.66666667f, 1e-3);
+            Assert.AreEqual(result[1], 10.88888889f, 1e-3);
+
+            result = tensor.Var(keepdim:true);
+
+            Console.WriteLine("tensor.Var(keepdim:true) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 1);
+            Assert.AreEqual(result.Shape[0], 1);
+            Assert.AreEqual(result.Size, 1);
+            Assert.AreEqual(result[0], 9.0666666666666664f, 1e-3);
+
+            result = tensor.Var(0,keepdim:true);
+
+            Console.WriteLine("tensor.Var(0,keepdim:true) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 2);
+            Assert.AreEqual(result.Shape[0], 1);
+            Assert.AreEqual(result.Shape[1], 3);
+            Assert.AreEqual(result.Size, 3);
+            Assert.AreEqual(result[0], 0.0);
+            Assert.AreEqual(result[1], 2.0);
+            Assert.AreEqual(result[2], 18.0);
+
+            result = tensor.Var(1,keepdim:true);
+
+            Console.WriteLine("tensor.Var(1,keepdim:true) {0}", string.Join(", ", result.Data));
+            Assert.AreEqual(result.Shape.Length, 2);
+            Assert.AreEqual(result.Shape[0], 2);
+            Assert.AreEqual(result.Shape[1], 1);
+            Assert.AreEqual(result.Size, 2);
+            Assert.AreEqual(result[0], 1.0);
+            Assert.AreEqual(result[1], 16.33333333f, 1e-3);
+        }
         [Test]
         public void View()
         {

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.Ops.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.Ops.cs
@@ -1616,10 +1616,7 @@ namespace OpenMined.Syft.Tensor
             int numSplits = splitSections.Length;
             var splits = new FloatTensor[numSplits];
             int offset = 0;
-
-            int off = 0;
-
-
+            
             for(int i = 0; i < numSplits; i++)
             {
                 int[] splitShape = (int[]) Shape.Clone();

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.Ops.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.Ops.cs
@@ -1616,7 +1616,8 @@ namespace OpenMined.Syft.Tensor
             int numSplits = splitSections.Length;
             var splits = new FloatTensor[numSplits];
             int offset = 0;
-            
+
+            //Gather subset of elements corresponding to each split 
             for(int i = 0; i < numSplits; i++)
             {
                 int[] splitShape = (int[]) Shape.Clone();

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.Ops.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.Ops.cs
@@ -956,7 +956,7 @@ namespace OpenMined.Syft.Tensor
             }
 
             // TODO: Implement GPU op. with GPU tests.
-            return Reduce(dim, keepdim, (acc, val, index, arr) => acc > val ? acc : val, (val, len) => val, creation_op:"max_"+dim);
+            return Reduce(dim, keepdim, (acc, val, index, arr) => acc > val ? acc : val, (val, len) => val, creation_op:"max_"+dim+"_"+keepdim);
         }        
 
         public FloatTensor Mean(int dim = -1, bool keepdim = false)
@@ -966,7 +966,7 @@ namespace OpenMined.Syft.Tensor
             }
             
             // TODO: Implement GPU op. with GPU tests.
-            return Reduce(dim, keepdim, (acc, val, index, arr) => acc + val, (val, len) => val / (float) len, creation_op:"mean_"+dim);
+            return Reduce(dim, keepdim, (acc, val, index, arr) => acc + val, (val, len) => val / (float) len, creation_op:"mean_"+dim+"_"+keepdim);
         }        
         
         public FloatTensor Min(int dim = -1, bool keepdim = false)
@@ -976,7 +976,7 @@ namespace OpenMined.Syft.Tensor
             }
 
             // TODO: Implement GPU op. with GPU tests.
-            return Reduce(dim, keepdim, (acc, val, index, arr) => acc < val ? acc : val, (val, len) => val, creation_op:"min_"+dim);
+            return Reduce(dim, keepdim, (acc, val, index, arr) => acc < val ? acc : val, (val, len) => val, creation_op:"min_"+dim+"_"+keepdim);
         }
 
         
@@ -1084,6 +1084,17 @@ namespace OpenMined.Syft.Tensor
             result.Data = data.AsParallel().Select(x => -x).ToArray();
             return result;
         }
+
+        public FloatTensor Norm(int dim = -1, bool keepdim = false, float p = 2, FloatTensor result = null)
+        {
+            if (p <= 0){
+                throw new InvalidOperationException("p must be greater than 0");
+            }
+            result = Pow(p).Sum(dim, keepdim).Pow(1/p);
+            
+            return result;
+
+        }
         
         public FloatTensor Pow(FloatTensor x, bool inline = false, FloatTensor result = null)
         {
@@ -1137,7 +1148,7 @@ namespace OpenMined.Syft.Tensor
             }
             
             // TODO: Implement GPU op. with GPU tests.
-            return Reduce(dim, keepdim, (acc, val, index, arr) => acc * val, (val, len) => val, creation_op:"prod_"+dim);
+            return Reduce(dim, keepdim, (acc, val, index, arr) => acc * val, (val, len) => val, creation_op:"prod_"+dim+"_"+keepdim);
         }
 
         public FloatTensor Random(int[] dims, float start = 0F, float? to = null, bool inline = true)
@@ -1266,7 +1277,7 @@ namespace OpenMined.Syft.Tensor
             });
 
             return result;
-        }        
+        }           
         
         public FloatTensor ReLU(bool inline = false, FloatTensor result = null)
         {
@@ -1600,44 +1611,77 @@ namespace OpenMined.Syft.Tensor
             return result;
         }
 
-        public FloatTensor Std(int dim = -1, bool unbiased=true)
+        internal FloatTensor[] MakeSplits(int[] splitSections, int dim = 0)
         {
-            FloatTensor avg;
-            
-            if (dim == -1)
+            int numSplits = splitSections.Length;
+            var splits = new FloatTensor[numSplits];
+            int offset = 0;
+
+            int off = 0;
+
+
+            for(int i = 0; i < numSplits; i++)
             {
-                var mean = Mean(dim: dim);
-                var diff = this.Sub(mean);
-                var sqdiff = diff.Pow(2);
-                if (unbiased)
-                {
-                    avg = sqdiff.Sum().Div(shape[0] - 1); // Bessel's correction
-                }
-                else
-                {
-                    avg = sqdiff.Mean(); 
-                }
-                var result = avg.Sqrt();
-                return result;
+                int[] splitShape = (int[]) Shape.Clone();
+                int splitSize = splitSections[i];
+                splitShape[dim] = splitSize;
+                splits[i] = this.IndexSelect(new List<int>(Enumerable.Range(offset, splitSize)), dim);
+
+                offset += splitSize;
             }
-            else
+            return splits;
+        }
+        
+        public FloatTensor[] Split(int splitSize, int dim = 0)
+        {
+            if (!IsContiguous())
             {
-                var mean = Mean(dim:dim, keepdim:true);
-                var diff = this.Sub(mean);
-                var sqdiff = diff.Pow(2);
-                
-                if(unbiased)
-                {
-                    avg = sqdiff.Sum(dim).Div(shape[0] - 1); // Bessel's correction
-                }
-                else
-                {
-                    avg = sqdiff.Mean(dim); 
-                }
-                var result = avg.Sqrt();
-                return result;
+                throw new InvalidOperationException ("Tensor must be contiguous, call Contiguous() to convert");
             }
-            
+
+            int len = shape.Length;
+
+            AssertDim(dim, len);
+
+            int numSplits = (shape[dim] + splitSize - 1)/splitSize;
+            int lastSplitSize = splitSize - (splitSize*numSplits - shape[dim]);
+            var splitSections = new int[numSplits];
+
+            for(int i = 0; i < numSplits; i++){
+                splitSections[i] = (i < (numSplits - 1)) ? splitSize : lastSplitSize;
+            }
+
+			return MakeSplits(splitSections, dim);
+        }
+
+        public FloatTensor[] Split(int[] splitSections, int dim = 0)
+        {
+
+            if (!IsContiguous())
+            {
+                throw new InvalidOperationException ("Tensor must be contiguous, call Contiguous() to convert");
+            }
+
+            int len = shape.Length;
+
+            AssertDim(dim, len);
+
+            int numSplits = splitSections.Length;
+            int sumSplitSizes = 0;
+        
+            for (int i = 0; i < numSplits; i++)
+            {
+                sumSplitSizes += splitSections[i];
+            }
+
+            if (sumSplitSizes != shape[dim])
+            {
+                throw new InvalidOperationException 
+                (String.Format("Sum of split sizes {0} != size {1} of dim {2}", 
+					sumSplitSizes,  shape[dim], dim));
+            }
+
+            return MakeSplits(splitSections, dim);
         }
         
         // TODO: Softmax will run on GPU, when below OPS have a GPU implementation!
@@ -1797,6 +1841,25 @@ namespace OpenMined.Syft.Tensor
             return result;
         }        
 
+        public FloatTensor Std(int dim = -1, bool keepdim = false, bool unbiased = true, FloatTensor result = null)
+        {
+            if(dataOnGpu)
+            {
+                throw new NotImplementedException();
+            }
+
+            if (!IsContiguous())
+            {
+                throw new InvalidOperationException ("Tensor must be contiguous, call Contiguous() to convert");
+            }
+
+            result = Var(dim, keepdim, unbiased).Sqrt();
+
+            // TODO: Implement GPU op. with GPU tests.
+            return result;
+        }
+
+
         public FloatTensor Sub(FloatTensor x, bool inline = false, FloatTensor result = null)
         {
             if (!IsContiguous() || !x.IsContiguous()) {
@@ -1873,7 +1936,7 @@ namespace OpenMined.Syft.Tensor
 
             // TODO: Implement GPU op. with GPU tests.
 
-            return Reduce(dim, keepdim, (acc, val, index, arr) => acc + val, (val, len) => val, creation_op:"sum_"+dim);
+            return Reduce(dim, keepdim, (acc, val, index, arr) => acc + val, (val, len) => val, creation_op:"sum_"+dim+"_"+keepdim);
 
         }        
         
@@ -2043,6 +2106,39 @@ namespace OpenMined.Syft.Tensor
 
             return View(new_shape, inline:inline);
         }        
+
+
+        public FloatTensor Var(int dim = -1, bool keepdim = false, bool unbiased = true, FloatTensor result = null)
+        {
+            if(dataOnGpu)
+            {
+                throw new NotImplementedException();
+            }
+
+            if (!IsContiguous())
+            {
+                throw new InvalidOperationException ("Tensor must be contiguous, call Contiguous() to convert");
+            }
+
+            if (unbiased)
+            {
+                //Bessel's correction: var(x) =  sum((x - mean(x))^2)/(n-1) = sum(x^2)/(n-1) - (sum(x)^2)/(n*(n-1))
+                int numElements = (dim == -1) ? size : shape[dim];
+                var meanTerm = Sum(dim, keepdim).Pow(2).Div(numElements);
+                var squareTerm = Pow(2).Sum(dim, keepdim);
+                result = squareTerm.Sub(meanTerm).Div(numElements-1);
+            }
+
+            else
+            {
+                var meanSquare = Mean(dim, keepdim).Pow(2);
+                var squareMean = Pow(2).Mean(dim, keepdim);
+                result = squareMean.Sub(meanSquare);
+            }
+
+            // TODO: Implement GPU op. with GPU tests.
+            return result;
+        }
         
         public FloatTensor View(int[] new_shape, bool inline = false, FloatTensor result = null)
         {

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.Ops.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.Ops.cs
@@ -1090,7 +1090,7 @@ namespace OpenMined.Syft.Tensor
             if (p <= 0){
                 throw new InvalidOperationException("p must be greater than 0");
             }
-            result = Pow(p).Sum(dim, keepdim).Pow(1/p);
+            result = Abs().Pow(p).Sum(dim, keepdim).Pow(1/p);
             
             return result;
 

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.cs
@@ -819,16 +819,11 @@ namespace OpenMined.Syft.Tensor
                     Sin(inline: true);
                     return Id.ToString();
                 }
-                //For splitting, though dim has a default value of zero
-                //we are getting it from msgObj.tensorIndexParams 
-                //because otherwise we have no way of knowing whether
-                //or not the last element is a split section
-                //or an axis dimension. But could perhaps use
-                //some sort of delimiter here. 
+
                 case "split_by_size":
                 {
                     int splitSize = int.Parse(msgObj.tensorIndexParams[0]);
-                    int dim = int.Parse(msgObj.tensorIndexParams[1]);
+                    int dim = 0;
 
                     if (msgObj.tensorIndexParams.Length > 1)
                     {
@@ -841,6 +836,13 @@ namespace OpenMined.Syft.Tensor
                     }
                     return string.Join(",",splitsString);
                 }
+
+                //TODO: For splitting, though dim has a default value of 0
+                //we are getting it from msgObj.tensorIndexParams 
+                //because otherwise we don't know whether
+                //the last element is a split size
+                //or an axis dimension. But could perhaps use
+                //a delimiter or do this some other way.
                 case "split_by_sections":
                 {
                     int numSections = msgObj.tensorIndexParams.Length-1;

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.cs
@@ -600,6 +600,21 @@ namespace OpenMined.Syft.Tensor
                     var result = this.MM(tensor_1);
                     return result.id + "";
                 }
+                case "norm":
+                {
+                    int dim = -1;
+                    bool keepdim = false;
+                    float p = 2;
+
+                    if (msgObj.tensorIndexParams.Length > 0)
+                    {
+                        dim = int.Parse(msgObj.tensorIndexParams[0]);
+                        keepdim = bool.Parse(msgObj.tensorIndexParams[1]);
+                        p = float.Parse(msgObj.tensorIndexParams[2]);
+                    }
+
+                    return Norm(dim: dim, keepdim: keepdim, p: p).Id.ToString();
+                }
                 case "pow_elem_":
                 {
                     var tensor_1 = factory.Get(int.Parse(msgObj.tensorIndexParams[0]));
@@ -804,6 +819,45 @@ namespace OpenMined.Syft.Tensor
                     Sin(inline: true);
                     return Id.ToString();
                 }
+                //For splitting, though dim has a default value of zero
+                //we are getting it from msgObj.tensorIndexParams 
+                //because otherwise we have no way of knowing whether
+                //or not the last element is a split section
+                //or an axis dimension. But could perhaps use
+                //some sort of delimiter here. 
+                case "split_by_size":
+                {
+                    int splitSize = int.Parse(msgObj.tensorIndexParams[0]);
+                    int dim = int.Parse(msgObj.tensorIndexParams[1]);
+
+                    if (msgObj.tensorIndexParams.Length > 1)
+                    {
+                        dim = int.Parse(msgObj.tensorIndexParams[1]);
+                    }
+                    FloatTensor[] splits = Split(splitSize, dim:dim);
+                    string[] splitsString = new string[splits.Length];
+                    for(int i = 0; i < splits.Length; i++){
+                        splitsString[i] = splits[i].Id.ToString();
+                    }
+                    return string.Join(",",splitsString);
+                }
+                case "split_by_sections":
+                {
+                    int numSections = msgObj.tensorIndexParams.Length-1;
+                    int[] splitSections = new int[numSections];
+                    int dim = int.Parse(msgObj.tensorIndexParams[numSections]);
+
+                    for (int i = 0; i < numSections; i++)
+                    {
+                        splitSections[i] = int.Parse(msgObj.tensorIndexParams[i]);
+                    }
+                    FloatTensor[] splits = Split(splitSections, dim:dim);
+                    string[] splitsString = new string[splits.Length];
+                    for(int i = 0; i < splits.Length; i++){
+                        splitsString[i] = splits[i].Id.ToString();
+                    }
+                    return string.Join(",",splitsString);
+                }
                 case "sqrt":
                 {
                     return Sqrt().id.ToString();
@@ -819,8 +873,20 @@ namespace OpenMined.Syft.Tensor
                 }
                 case "std":
                 {
-                    return Std(int.Parse(msgObj.tensorIndexParams[0])).Id + "";
+                    int dim = -1;
+                    bool keepdim = false;
+                    bool unbiased = true;
+
+                    if (msgObj.tensorIndexParams.Length > 0)
+                    {
+                        dim = int.Parse(msgObj.tensorIndexParams[0]);
+                        keepdim = bool.Parse(msgObj.tensorIndexParams[1]);
+                        unbiased = bool.Parse(msgObj.tensorIndexParams[2]);
+                    }
+
+                    return Std(dim: dim, keepdim: keepdim, unbiased: unbiased).Id.ToString();
                 }
+
                 case "sub_scalar":
                 {
                     return Sub(float.Parse(msgObj.tensorIndexParams[0])).Id + "";
@@ -921,6 +987,21 @@ namespace OpenMined.Syft.Tensor
                 {
                     var result = Unsqueeze(int.Parse(msgObj.tensorIndexParams[0]),inline:true);
                     return result.Id.ToString();
+                }
+                case "var":
+                {
+                    int dim = -1;
+                    bool keepdim = false;
+                    bool unbiased = true;
+
+                    if (msgObj.tensorIndexParams.Length > 0)
+                    {
+                        dim = int.Parse(msgObj.tensorIndexParams[0]);
+                        keepdim = bool.Parse(msgObj.tensorIndexParams[1]);
+                        unbiased = bool.Parse(msgObj.tensorIndexParams[2]);
+                    }
+
+                    return Var(dim: dim, keepdim: keepdim, unbiased: unbiased).Id.ToString();
                 }
                 case "view":
                 {
@@ -1025,14 +1106,13 @@ namespace OpenMined.Syft.Tensor
                 {
                     int dim = -1;
                     bool keepdim = false;
-
+                    
                     if (msgObj.tensorIndexParams.Length > 0)
                     {
                         dim = int.Parse(msgObj.tensorIndexParams[0]);
                         keepdim = bool.Parse(msgObj.tensorIndexParams[1]);
                     }
 
-            
                     return  Sum(dim: dim, keepdim: keepdim).Id.ToString();
                 }
                 case "prod":


### PR DESCRIPTION
# Description

Fixed op naming issue with functions that call Reduce which was leading to keepdim not functioning properly because the same op was getting reused. Also added Var, Std, Norm and Split (#627, #593, #544 and #588) in FloatTensor.Ops.cs and FloatTensor.cs. Replaced existing Std function which had limited functionality with Var and Std which calls Var. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Added tests for an existing feature

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* CPU:
* GPU:
* PySyft Version:
* Unity Version:
* OpenMined Unity App Version:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

  