### PR TITLE
fix `Failed executing external process for 'Bake Runtime' job.` error in Ubuntu

### DIFF
--- a/UnityProject/Assets/OpenMinedMain.unity
+++ b/UnityProject/Assets/OpenMinedMain.unity
@@ -43,7 +43,7 @@ RenderSettings:
 LightmapSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 11
-  m_GIWorkflowMode: 0
+  m_GIWorkflowMode: 1
   m_GISettings:
     serializedVersion: 2
     m_BounceScale: 1


### PR DESCRIPTION
# Description
turned off lighting settings to avoid a continuous stream of compilation errors stating: `Failed executing external process for 'Bake Runtime' job.`
