### PR TITLE
implemented negate in CPU and GPU for IntTensor and tests #1075, #1076, #1077, #1078

### DIFF
--- a/UnityProject/Assets/OpenMined.Tests/Editor/IntTensor/IntTensorGpuTest.cs
+++ b/UnityProject/Assets/OpenMined.Tests/Editor/IntTensor/IntTensorGpuTest.cs
@@ -117,6 +117,42 @@ namespace OpenMined.Tests.Editor.IntTensorTests
             AssertEqualTensorsData(expectedTensor, tensor1);
         }
 
+		[Test]
+		public void Neg()
+		{
+			int[] shape1 = { 2, 5 };
+			int[] data1 = { -1, -2, -3, -4, 5, 6, 7, 8, -999, 10 };
+			var tensor1 = ctrl.intTensorFactory.Create(_data: data1, _shape: shape1);
+			tensor1.Gpu(shader);
+
+			int[] expectedData1 = { 1, 2, 3, 4, -5, -6, -7, -8, 999, -10 };
+			int[] shape2 = { 2, 5 };
+			var expectedTensor1 = ctrl.intTensorFactory.Create(_data: expectedData1, _shape: shape2);
+			expectedTensor1.Gpu(shader);
+
+			var actualTensorNeg1 = tensor1.Neg();
+
+			AssertEqualTensorsData(expectedTensor1, actualTensorNeg1);
+		}
+
+		[Test]
+		public void Neg_()
+		{
+			int[] shape1 = { 2, 5 };
+			int[] data1 = { -1, -2, -3, -4, 5, 6, 7, 8, -999, 10 };
+			var tensor1 = ctrl.intTensorFactory.Create(_data: data1, _shape: shape1);
+			tensor1.Gpu(shader);
+
+			int[] expectedData1 = { 1, 2, 3, 4, -5, -6, -7, -8, 999, -10 };
+			int[] shape2 = { 2, 5 };
+			var expectedTensor1 = ctrl.intTensorFactory.Create(_data: expectedData1, _shape: shape2);
+			expectedTensor1.Gpu(shader);
+
+			tensor1.Neg(inline: true);
+
+			AssertEqualTensorsData(expectedTensor1, tensor1);
+		}
+
 /* closes class and namespace */
     }
 }

--- a/UnityProject/Assets/OpenMined.Tests/Editor/IntTensor/IntTensorTest.cs
+++ b/UnityProject/Assets/OpenMined.Tests/Editor/IntTensor/IntTensorTest.cs
@@ -99,6 +99,44 @@ namespace OpenMined.Tests.Editor.IntTensorTests
             }
         }
 
+		[Test]
+		public void Neg()
+		{
+			int[] shape1 = { 2, 5 };
+			int[] data1 = { -1, -2, -3, -4, 5, 6, 7, 8, -999, 10 };
+			var tensor1 = ctrl.intTensorFactory.Create(_data: data1, _shape: shape1);
+
+			int[] expectedData1 = { 1, 2, 3, 4, -5, -6, -7, -8, 999, -10 };
+			int[] shape2 = { 2, 5 };
+			var expectedTensor1 = ctrl.intTensorFactory.Create(_data: expectedData1, _shape: shape2);
+
+			var actualTensorNeg1 = tensor1.Neg();
+
+			for (int i = 0; i < actualTensorNeg1.Size; i++)
+			{
+				Assert.AreEqual(expectedTensor1[i], actualTensorNeg1[i]);
+			}
+		}
+
+		[Test]
+		public void Neg_()
+		{
+			int[] shape1 = { 2, 5 };
+			int[] data1 = { -1, -2, -3, -4, 5, 6, 7, 8, -999, 10 };
+			var tensor1 = ctrl.intTensorFactory.Create(_data: data1, _shape: shape1);
+
+			int[] expectedData1 = { 1, 2, 3, 4, -5, -6, -7, -8, 999, -10 };
+			int[] shape2 = { 2, 5 };
+			var expectedTensor1 = ctrl.intTensorFactory.Create(_data: expectedData1, _shape: shape2);
+
+			tensor1.Neg(inline: true);
+
+			for (int i = 0; i < tensor1.Size; i++)
+			{
+				Assert.AreEqual(expectedTensor1[i], tensor1[i]);
+			}
+		}
+
         [Test]
         public void Trace()
         {

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/Ops/Shaders/Shaders.compute
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/Ops/Shaders/Shaders.compute
@@ -483,6 +483,23 @@ void Negate_ (uint3 id: SV_DispatchThreadID) {
 	NegateData_[id.x] = -NegateData_[id.x];
 }
 
+#pragma kernel NegateInt
+
+StructuredBuffer<int> NegateIntData;
+RWStructuredBuffer<int> NegateIntResult;
+[numthreads(4,1,1)]
+void NegateInt (uint3 id: SV_DispatchThreadID) {
+	NegateIntResult[id.x] = -NegateIntData[id.x];
+}
+
+#pragma kernel NegateInt_
+
+RWStructuredBuffer<int> NegateIntData_;
+[numthreads(4,1,1)]
+void NegateInt_ (uint3 id: SV_DispatchThreadID) {
+	NegateIntData_[id.x] = -NegateIntData_[id.x];
+}
+
 #pragma kernel Reduce1DSum
 #define REDUCE1D_NUMTHREADS 8
 


### PR DESCRIPTION
# Description

Implemented IntTensor negate for CPU and GPU in Unity with tests. 

Fixes 
OpenMined/PySyft#1075 
OpenMined/PySyft#1076 
OpenMined/PySyft#1077  
OpenMined/PySyft#1078

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests in Unity-- see IntTensorTests

**Test Configuration**:
* CPU:
* GPU:
* PySyft Version:
* Unity Version:
* OpenMined Unity App Version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
