### PR TITLE
Add negate gpu for int tensor

### DIFF
--- a/UnityProject/Assets/OpenMined.Tests/Editor/IntTensor/IntTensorGpuTest.cs
+++ b/UnityProject/Assets/OpenMined.Tests/Editor/IntTensor/IntTensorGpuTest.cs
@@ -117,6 +117,24 @@ namespace OpenMined.Tests.Editor.IntTensorTests
             AssertEqualTensorsData(expectedTensor, tensor1);
         }
 
+        [Test]
+        public void Negate()
+        {
+            int[] data1 = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+            int[] shape1 = {2, 5};
+            var tensor1 = ctrl.intTensorFactory.Create(_data: data1, _shape: shape1);
+            tensor1.Gpu(shader);
+
+            int[] data2 = {-1, -2, -3, -4, -5, -6, -7, -8, -9, -10};
+            int[] shape2 = {2, 5};
+            var expectedTensor = ctrl.intTensorFactory.Create(_data: data2, _shape: shape2);
+            expectedTensor.Gpu(shader);
+
+            var tensorNegateGpu = tensor1.Negate();
+
+            AssertEqualTensorsData(expectedTensor, tensorNegateGpu);
+        }
+
 /* closes class and namespace */
     }
 }

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/IntTensor.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/IntTensor.cs
@@ -21,6 +21,7 @@ namespace OpenMined.Syft.Tensor
         // kernel pointers
         [SerializeField] 
         private static int AddElemIntKernel;
+        private static int NegateKernel;
 
 
         public IntTensor()
@@ -143,6 +144,7 @@ namespace OpenMined.Syft.Tensor
         public void initShaderKernels()
         {
             //AddElemIntKernel = this.shader.FindKernel("AddElemInt");
+//            NegateKernel = this.shader.FindKernel("NegateInt");
         }
 
         public IntTensor Copy()
@@ -189,6 +191,28 @@ namespace OpenMined.Syft.Tensor
             IntTensor result = factory.Create(this.shape);
             result.Data = data.AsParallel().Select(x => x + value).ToArray();
 
+            return result;
+        }
+        
+        public IntTensor Negate()
+        {
+            IntTensor result = factory.Create(this.shape);
+            
+            if (dataOnGpu)
+            {
+                // move result tensor to GPU - TODO: init on gpu instead
+                result.Gpu(shader);
+                
+                int kernel_id = shader.FindKernel("NegateInt");
+             
+                // find kernel - TOOD: find all kernels in factory
+                shader.SetBuffer(kernel_id, "NegateIntData", dataBuffer);
+                shader.SetBuffer(kernel_id, "NegateIntResult", result.dataBuffer);
+                shader.Dispatch(kernel_id, size, 1, 1);
+                return result;
+            }
+                
+            throw new NotImplementedException();
             return result;
         }
 

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/Ops/Shaders/Shaders.compute
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/Ops/Shaders/Shaders.compute
@@ -472,6 +472,15 @@ void Negate_ (uint3 id: SV_DispatchThreadID) {
 	NegateData_[id.x] = -NegateData_[id.x];
 }
 
+#pragma kernel NegateInt
+
+StructuredBuffer<int> NegateIntData;
+RWStructuredBuffer<int> NegateIntResult;
+[numthreads(4,1,1)]
+void NegateInt (uint3 id: SV_DispatchThreadID) {
+    NegateIntResult[id.x] = -NegateIntData[id.x];
+}
+
 #pragma kernel Reduce1DSum
 #define REDUCE1D_NUMTHREADS 8
 


### PR DESCRIPTION
# Description

Adding the GPU implementation of neg()  to our IntTensor class with the appropriate functionality, returning a new tensor.

Fixes # (issue)

https://github.com/OpenMined/PySyft/issues/1077

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added a unit test to check the output of the function. The input should be the negative of the input.

**Test Configuration**:
* CPU: mac 2015 mbp 15" (2.8 GHz Intel Core i7)
* GPU: AMD Radeon R9 M370X 2 GB - Intel Iris Pro 1536 MB
* PySyft Version: latest
* Unity Version: latest
* OpenMined Unity App Version: latest, master

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
