### PR TITLE
Keep track of the usage count of tensor

### DIFF
--- a/UnityProject/Assets/OpenMined/Syft/Tensor/BaseTensor.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/BaseTensor.cs
@@ -26,6 +26,7 @@ namespace OpenMined.Syft.Tensor
 
         protected ComputeShader shader;
 
+        protected int usage_count;
         #endregion
 
         #region Properties
@@ -58,6 +59,12 @@ namespace OpenMined.Syft.Tensor
         {
             get { return size; }
             protected set { size = value; }
+        }
+
+        public int Usage_count
+        {
+            get { return usage_count; }
+            protected set { usage_count = value; }
         }
 
         public int Id

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.Graph.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.Graph.cs
@@ -80,6 +80,8 @@ namespace OpenMined.Syft.Tensor
 						{
 							child_pre_initialized = true;
 							child_index = children_indices[i];
+							// Keep track of how often each tensor is used for safe deletion
+							child.Usage_count = child.Usage_count + 1;
 							break;
 						}
 						
@@ -102,6 +104,8 @@ namespace OpenMined.Syft.Tensor
 						// found a child that matches all parameters
 						child_pre_initialized = true;
 						child_index = children_indices[i];
+						// Keep track of how often each tensor is used for safe deletion
+                        child.Usage_count = child.Usage_count + 1;
 						break;
 
 					}

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.Ops.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.Ops.cs
@@ -75,8 +75,7 @@ namespace OpenMined.Syft.Tensor
 		public FloatTensor Abs(bool inline = false, FloatTensor result = null)
 		// Returns a new Tensor with the smallest integer greater than or equal to each element
 		{
-            result = HookGraph(ref result, "abs", inline);		
-
+            result = HookGraph(ref result, "abs", inline);
 			if (dataOnGpu) {
 				if (inline) { AbsGPU_ (); return this; }
 				else { return AbsGPU (result); }
@@ -548,7 +547,14 @@ namespace OpenMined.Syft.Tensor
 
         public void Delete()
         {
-            factory.ctrl.floatTensorFactory.Delete(this.Id);
+            // Lower the usage count by 1 when a tensor is deleted.
+            this.Usage_count = this.Usage_count -1;
+
+            // Only delete a tensor if it is just used once
+            if (this.Usage_count < 1)
+            {
+                factory.ctrl.floatTensorFactory.Delete(this.Id);
+            }
         }
 
         public FloatTensor Div(FloatTensor x, bool inline = false, FloatTensor result = null)

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.cs
@@ -42,7 +42,7 @@ namespace OpenMined.Syft.Tensor
             autograd = _autograd;
             keepgrads = _keepgrads;
             creation_op = _creation_op;
-
+            usage_count = 1;
             InitGraph();
             
             if (autograd)


### PR DESCRIPTION
Keep track of the usage count of tensor

# Description
Keep track of the usage count of each tensor using a variable `Usage_count`. Increase this variable by 1 when a tensor is re-used (using hookgraph) and only delete a tensor if it's just used once.

Fixes # (issue)
This fixes the issue described here: https://github.com/OpenMined/PySyft/pull/761

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Added tests for an existing feature

# How Has This Been Tested?
Tested in jupyter notebook with the following code:
```a = FloatTensor(data)
b = a.max()
c = a.max()
c.delete_after_use = True
b.delete_after_use = True
c = 0
print(b)
b = 0
```
After which the tensor is deleted in the Unity log. Also logging the value of usage_count it shows that it increases when you re-use the tensor and then decreases when you remove one variable.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
