### PR TITLE
Remove tensor from the graph of its creator(s) when deleted

### DIFF
--- a/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.Graph.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.Graph.cs
@@ -40,6 +40,12 @@ namespace OpenMined.Syft.Tensor
 		    	children_counts[i] = 0;
 	    }
 
+	    public void RemoveChild(int tensorId)
+	    {
+	        bool deleted = this.children_indices.Remove(tensorId);
+	        if(deleted) this.children_counts.RemoveAt(0);
+	    }
+
 	    public FloatTensor HookGraph(ref FloatTensor result, 
 		    						string creation_op, 
 		    						bool inline, 
@@ -173,7 +179,6 @@ namespace OpenMined.Syft.Tensor
 				result.InitGraph();
 				result.creators.Add(this.id);
 				result.creation_op = creation_op;
-				
 				children_indices.Add(result.Id);
 				children_counts.Add(0);
 				

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.Ops.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/FloatTensor.Ops.cs
@@ -549,10 +549,14 @@ namespace OpenMined.Syft.Tensor
         {
             // Lower the usage count by 1 when a tensor is deleted.
             this.Usage_count = this.Usage_count -1;
-
             // Only delete a tensor if it is just used once
             if (this.Usage_count < 1)
             {
+                // When you delete a tensor also remove it from the graph of its creator(s)
+                foreach(int creator_id in this.creators)
+                {
+                    factory.ctrl.floatTensorFactory.Get(creator_id).RemoveChild(this.Id);
+                }
                 factory.ctrl.floatTensorFactory.Delete(this.Id);
             }
         }


### PR DESCRIPTION
# Description
As mentioned here: https://github.com/OpenMined/OpenMined/pull/370 when you do an operation without storing the value and then try to do the same operation again, the tensor will try to retrieve the result of the operation from the graph eventhough it doesn't exist anymore.

To solve this I make sure to delete the FloatTensor from the children_indices in its creator(s). I think this should completely solve the issue of not finding a tensor that has been deleted earlier.

Fixes # (issue) https://github.com/OpenMined/OpenMined/pull/370

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Added tests for an existing feature

# How Has This Been Tested?
Tested with several examples in a jupyter notebook using debug logs to see when children are deleted. You can see that this works by trying:
 ```
a = FloatTensor(np.array([3,5,2]))
a.max()
a.max()
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
