### PR TITLE
Change/process message async

### DIFF
--- a/UnityProject/Assets/OpenMined/Config/config.json
+++ b/UnityProject/Assets/OpenMined/Config/config.json
@@ -1,5 +1,5 @@
 {
-  "trainer": true,
+  "trainer": false,
   "identify": false,
   "bygoneServer": "192.168.2.14"
 }

--- a/UnityProject/Assets/OpenMined/Config/config.json
+++ b/UnityProject/Assets/OpenMined/Config/config.json
@@ -1,5 +1,5 @@
 {
   "trainer": false,
   "identify": false,
-  "bygoneServer": "192.168.2.14"
+  "bygoneServer": "localhost"
 }

--- a/UnityProject/Assets/OpenMined/Config/config.json
+++ b/UnityProject/Assets/OpenMined/Config/config.json
@@ -1,5 +1,5 @@
 {
-  "trainer": false,
+  "trainer": true,
   "identify": false,
-  "bygoneServer": "localhost"
+  "bygoneServer": "192.168.2.14"
 }

--- a/UnityProject/Assets/OpenMined/Network/Controllers/Grid.cs
+++ b/UnityProject/Assets/OpenMined/Network/Controllers/Grid.cs
@@ -34,16 +34,20 @@ namespace OpenMined.Network.Controllers
             getResultRequest.RunRequestSync();
             var responseHash = getResultRequest.GetResponse().resultAddress;
 
-            // load the model into memory
-            var response = Ipfs.Get<IpfsJob>(responseHash);
-            if (response == null)
+            while (responseHash == "")
             {
-                // try again in 5 seconds
                 Debug.Log(string.Format("Could not load job {0}. Trying again in 5 seconds.", job));
                 await Task.Delay(5000);
-                return await LoadModelFromJob(job);
+
+                // run the request again
+                getResultRequest = new GetResultsRequest(job);
+                getResultRequest.RunRequestSync();
+                responseHash = getResultRequest.GetResponse().resultAddress;
             }
 
+            // load the model into memory
+
+            var response = Ipfs.Get<IpfsJob>(responseHash);
             var modelDefinition = response.Model;
             var model = this.CreateSequential(modelDefinition);
 

--- a/UnityProject/Assets/OpenMined/Network/Controllers/Grid.cs
+++ b/UnityProject/Assets/OpenMined/Network/Controllers/Grid.cs
@@ -166,14 +166,27 @@ namespace OpenMined.Network.Controllers
                         var weightTensor = controller.floatTensorFactory.Create(_data: weightData, _shape: weightShape, _autograd: true);
 
                         // bias float tensor
-                        var biasData = layer.SelectToken("config.bias.data").ToObject<float[]>();
-                        var biasShape = layer.SelectToken("config.bias.shape").ToObject<int[]>();
-                        var biasTensor = controller.floatTensorFactory.Create(_data: biasData, _shape: biasShape, _autograd: true);
 
-                        var input = layer.SelectToken("config.input").ToObject<int>();
-                        var output = layer.SelectToken("config.output").ToObject<int>();
+                        Linear linear = null;
+                        if (layer.SelectToken("config.bias") == null)
+                        {
+                            var biasData = layer.SelectToken("config.bias.data").ToObject<float[]>();
+                            var biasShape = layer.SelectToken("config.bias.shape").ToObject<int[]>();
+                            var biasTensor = controller.floatTensorFactory.Create(_data: biasData, _shape: biasShape, _autograd: true);
 
-                        var linear = new Linear(controller, input: input, output: output, weights: weightTensor, bias: biasTensor);
+                            var input = layer.SelectToken("config.input").ToObject<int>();
+                            var output = layer.SelectToken("config.output").ToObject<int>();
+
+                            linear = new Linear(controller, input: input, output: output, weights: weightTensor, bias: biasTensor);
+                        }
+                        else
+                        {
+                            var input = layer.SelectToken("config.input").ToObject<int>();
+                            var output = layer.SelectToken("config.output").ToObject<int>();
+
+                            linear = new Linear(controller, input: input, output: output, weights: weightTensor);
+                        }
+
                         seq.AddLayer(linear);
                         break;
                     case "ReLU":

--- a/UnityProject/Assets/OpenMined/Network/Servers/SyftServer.cs
+++ b/UnityProject/Assets/OpenMined/Network/Servers/SyftServer.cs
@@ -7,7 +7,6 @@ using Newtonsoft.Json.Linq;
 
 namespace OpenMined.Network.Servers
 {
-
 	public class SyftServer : MonoBehaviour
 	{
 		public bool Connected;
@@ -20,21 +19,15 @@ namespace OpenMined.Network.Servers
 
 		private void Start()
 		{
-			_netMqPublisher = new NetMqPublisher(HandleMessage);
-			_netMqPublisher.Start();
+            controller = new SyftController(shader);
 
-			controller = new SyftController(shader);
+            _netMqPublisher = new NetMqPublisher(controller, this);
+			_netMqPublisher.Start();
 		}
 
 		private void Update()
 		{
 			_netMqPublisher.Update();
-		}
-
-		private string HandleMessage(string message)
-		{
-			//Debug.LogFormat("HandleMessage... {0}", message);
-			return controller.processMessage(message, this);
 		}
 
 		private void OnDestroy()

--- a/UnityProject/Assets/OpenMined/Syft/NN/Linear.cs
+++ b/UnityProject/Assets/OpenMined/Syft/NN/Linear.cs
@@ -30,7 +30,7 @@ namespace OpenMined.Syft.Layer
 
             _biased = biased || bias != null;
 
-            int[] weightShape = { output, input };
+            int[] weightShape = { input, output };
             if (weights == null)
             {
                 weights = initializer == "Xavier" ? controller.RandomWeights(input * output, input) : controller.RandomWeights(input * output);

--- a/UnityProject/Assets/OpenMined/Syft/NN/Linear.cs
+++ b/UnityProject/Assets/OpenMined/Syft/NN/Linear.cs
@@ -22,7 +22,6 @@ namespace OpenMined.Syft.Layer
 		{
             init(name);
 
-
 			this.controller = _controller;
 			
 			_input = input;
@@ -45,8 +44,6 @@ namespace OpenMined.Syft.Layer
                 _bias = controller.floatTensorFactory.Create(_data: bias, _shape: biasShape, _autograd: true);
                 parameters.Add(_bias.Id);
             };
-
-
 
             #pragma warning disable 420
             id = System.Threading.Interlocked.Increment(ref nCreated);
@@ -105,7 +102,7 @@ namespace OpenMined.Syft.Layer
 				{ "dtype", "float32" }, 
 				{ "output", _output },
                 { "input", _input },
-                { "bias", _bias.GetConfig() },
+                { "bias", _bias?.GetConfig() },
                 { "weights", _weights.GetConfig() },
 				{ "activation", "linear" },
 				{ "use_bias", true },

--- a/UnityProject/Assets/OpenMined/Syft/NN/Linear.cs
+++ b/UnityProject/Assets/OpenMined/Syft/NN/Linear.cs
@@ -107,7 +107,6 @@ namespace OpenMined.Syft.Layer
 				{ "output", _output },
                 { "input", _input },
                 { "bias", _bias?.GetConfig() },
-                { "weights", _weights.GetConfig() },
                 { "weights", _weights?.GetConfig() },
 				{ "activation", "linear" },
 				{ "use_bias", true },

--- a/UnityProject/Assets/OpenMined/Syft/NN/Linear.cs
+++ b/UnityProject/Assets/OpenMined/Syft/NN/Linear.cs
@@ -50,7 +50,7 @@ namespace OpenMined.Syft.Layer
             controller.addModel(this);
         }
 
-        public Linear (SyftController _controller, int input, int output, FloatTensor weights, FloatTensor bias, string initializer="Xavier")
+        public Linear (SyftController _controller, int input, int output, FloatTensor weights, FloatTensor bias = null, string initializer="Xavier")
         {
             init(this.name);
 
@@ -63,7 +63,11 @@ namespace OpenMined.Syft.Layer
             _bias = bias;
 
             parameters.Add(_weights.Id);
-            parameters.Add(_bias.Id);
+
+            if (_bias != null)
+            {
+                parameters.Add(_bias.Id);
+            }
 
             #pragma warning disable 420
             id = System.Threading.Interlocked.Increment(ref nCreated);
@@ -104,6 +108,7 @@ namespace OpenMined.Syft.Layer
                 { "input", _input },
                 { "bias", _bias?.GetConfig() },
                 { "weights", _weights.GetConfig() },
+                { "weights", _weights?.GetConfig() },
 				{ "activation", "linear" },
 				{ "use_bias", true },
 				{


### PR DESCRIPTION
Before, `SyftController.ProcessMessage` was synchronous and was required
to return a string value.

I have changed the function definition to return void, and it is passed
a callback which you should call with a string, what you pass the
callback is passed back to the client.

This allows you to leave the main thread and call the callback at a
later date.

Grid takes advantage of this, when you call `getResults`, they may not
be available yet so we wait for them.  The only wait to wait and check
again is to pause, since this was running on the main thread it would
completely freeze unity, not ideal!

check out `Grid.cs` for an example of how I used this.