### PR TITLE
Implement the Acos function for IntTensor on the CPU #830

### DIFF
--- a/UnityProject/Assets/OpenMined.Tests/Editor/IntTensor/IntTensorTest.cs
+++ b/UnityProject/Assets/OpenMined.Tests/Editor/IntTensor/IntTensorTest.cs
@@ -81,6 +81,24 @@ namespace OpenMined.Tests.Editor.IntTensorTests
         }
 
         [Test]
+        public void Acos(){
+            int[] data1 = { 1, 0, -1, 1, 1, 0 };
+            int[] shape1 = { 6 };
+            var tensor1 = ctrl.intTensorFactory.Create(_data: data1, _shape: shape1);
+
+            float[] data2 = { 0, 1.57079633f, 3.14159265f, 0, 0, 1.57079633f };
+            int[] shape2 = { 6 };
+            var expectedTensor = ctrl.floatTensorFactory.Create(_data: data2, _shape: shape2);
+
+            var actualTensorAcos = tensor1.Acos();
+
+            for (int i = 0; i < actualTensorAcos.Size; i++)
+            {
+                Assert.AreEqual(actualTensorAcos[i], expectedTensor[i]);
+            }
+        }
+
+        [Test]
         public void Add()
         {
             float[] data1 = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/IntTensor.Ops.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/IntTensor.Ops.cs
@@ -21,6 +21,19 @@ namespace OpenMined.Syft.Tensor
             return result;
         }
 
+        public FloatTensor Acos(bool inline = false)
+        {
+            FloatTensor result = factory.ctrl.floatTensorFactory.Create(this.shape);
+
+            if (dataOnGpu)
+            {
+                throw new NotImplementedException();
+            }
+            result.Data = data.AsParallel().Select(x => (float)Math.Acos((double)x)).ToArray();
+
+            return result;
+        }
+
         public IntTensor Add(IntTensor x, bool inline = false)
         {
 

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/IntTensor.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/IntTensor.cs
@@ -158,6 +158,11 @@ namespace OpenMined.Syft.Tensor
                     var result = this.Abs(inline:true);
                     return result.id + "";
                 }
+                case "acos":
+                {
+                    var result = Acos();
+                    return result.Id.ToString();
+                }
                 case "lt":
                 {
                     var compareToTensor = factory.Get(int.Parse(msgObj.tensorIndexParams[0]));

--- a/integration/test_int_tensor.py
+++ b/integration/test_int_tensor.py
@@ -33,6 +33,19 @@ def test_int_abs_():
     np.testing.assert_almost_equal(a.to_numpy(), expected,
                                    decimal=decimal_accuracy, verbose=verbosity)
 
+def test_int_cos():
+    data = np.array([30, 60, 90, 180])
+    expected = np.array([.1542515, -0.952413, -0.4480736, -0.5984601])
+    a = IntTensor(data)
+    b = a.cos()
+
+    np.testing.assert_almost_equal(b.to_numpy(), expected,
+                                   decimal=decimal_accuracy, verbose=verbosity)
+    # a doesn't change (non-inline)
+    np.testing.assert_almost_equal(a.to_numpy(), data,
+                                   decimal=decimal_accuracy, verbose=verbosity)
+
+
 def test_int_lt():
     data = np.array([1,2,3,4])
     compare_data = np.array([2,2,5,1])
@@ -107,6 +120,17 @@ def test_int_shape():
     assert(a.shape() == a_expected)
     assert(b.shape() == b_expected)
 
+def test_int_sin():
+    data = np.array([15, 60, 90, 180])
+    expected = np.array([0.65028784, -0.30481062, 0.89399666, -0.80115264])
+    a = IntTensor(data)
+    b = a.sin()
+
+    np.testing.assert_almost_equal(b.to_numpy(), expected,
+                                   decimal=decimal_accuracy, verbose=verbosity)
+    # a doesn't change
+    np.testing.assert_almost_equal(a.to_numpy(), data,
+                                   decimal=decimal_accuracy, verbose=verbosity)
 
 def test_int_sqrt():
     data = np.random.rand(3,2)

--- a/integration/test_int_tensor.py
+++ b/integration/test_int_tensor.py
@@ -46,6 +46,18 @@ def test_int_cos():
                                    decimal=decimal_accuracy, verbose=verbosity)
 
 
+def test_int_acos():
+    data = np.array([-1, 0, 1, 1, 2])
+    expected = np.array([3.14159265, 1.57079633, 0, 0, np.nan])
+    a = IntTensor(data)
+    b = a.acos()
+
+    np.testing.assert_almost_equal(b.to_numpy(), expected,
+                                   decimal=decimal_accuracy, verbose=verbosity)
+    # a doesn't change
+    np.testing.assert_almost_equal(a.to_numpy(), data,
+                                   decimal=decimal_accuracy, verbose=verbosity)
+
 def test_int_lt():
     data = np.array([1,2,3,4])
     compare_data = np.array([2,2,5,1])

--- a/notebooks/tests/Test Tensor Function Implementations.ipynb
+++ b/notebooks/tests/Test Tensor Function Implementations.ipynb
@@ -58,7 +58,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import torch"
@@ -263,6 +265,35 @@
     "data = np.array([1, 3, 20, 100]).astype('int')\n",
     "a = IntTensor(data)\n",
     "a.cos().to_numpy()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<b>acos()</b>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 3.141593,  1.570796,  0.      ,  0.      ,  1.570796,       nan])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data = np.array([-1,0,1,1,0,-2])\n",
+    "a = IntTensor(data)\n",
+    "a.acos().to_numpy()"
    ]
   },
   {

--- a/notebooks/tests/Test Tensor Function Implementations.ipynb
+++ b/notebooks/tests/Test Tensor Function Implementations.ipynb
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -92,7 +92,7 @@
        "[syft.IntTensor:3 size:4]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -116,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -126,7 +126,7 @@
        "[syft.IntTensor:4 size:4]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -150,17 +150,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "[0 1 1 1 1 1]\n",
-       "[syft.IntTensor:12 size:6]"
+       "[syft.IntTensor:8 size:6]"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -172,6 +172,30 @@
     "b = IntTensor(np.array([2,-2,3,4,5,-6]).astype('int'))\n",
     "\n",
     "# test eq function\n",
+    "a.eq(b)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[0 1 1 1 1 1]\n",
+       "[syft.IntTensor:9 size:6]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# gpu version\n",
+    "a.gpu()\n",
+    "b.gpu()\n",
     "a.eq(b)"
    ]
   },
@@ -206,6 +230,30 @@
     "b = IntTensor(np.array([2,-2,3,4,5,-6]).astype('int'))\n",
     "\n",
     "# test eq function\n",
+    "a.eq_(b)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[0 1 1 1 1 1]\n",
+       "[syft.IntTensor:6 size:6]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# gpu version\n",
+    "a.gpu()\n",
+    "b.gpu()\n",
     "a.eq_(b)"
    ]
   },

--- a/notebooks/tests/Test Tensor Function Implementations.ipynb
+++ b/notebooks/tests/Test Tensor Function Implementations.ipynb
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {

--- a/notebooks/tests/Test Tensor Function Implementations.ipynb
+++ b/notebooks/tests/Test Tensor Function Implementations.ipynb
@@ -30,17 +30,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/anaconda3/lib/python3.6/site-packages/IPython/html.py:14: ShimWarning: The `IPython.html` package has been deprecated since IPython 4.0. You should import from `notebook` instead. `IPython.html.widgets` has moved to `ipywidgets`.\n",
-      "  \"`IPython.html.widgets` has moved to `ipywidgets`.\", ShimWarning)\n",
-      "Import warning: PyTorch capabilities not available due to torch module not found on your system\n",
-      "How to install PyTorch: http://pytorch.org/"
+      "/Users/Chat/anaconda3/envs/py36/lib/python3.6/site-packages/IPython/html.py:14: ShimWarning: The `IPython.html` package has been deprecated since IPython 4.0. You should import from `notebook` instead. `IPython.html.widgets` has moved to `ipywidgets`.\n",
+      "  \"`IPython.html.widgets` has moved to `ipywidgets`.\", ShimWarning)\n"
      ]
     }
    ],
@@ -59,21 +57,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ModuleNotFoundError",
-     "evalue": "No module named 'torch'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-4-c031d3dd82fc>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mimport\u001b[0m \u001b[0mtorch\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'torch'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import torch"
    ]
@@ -219,6 +205,64 @@
     "\n",
     "# test eq function\n",
     "a.eq_(b)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<b>sin()</b>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 0.841471 ,  0.14112  ,  0.9129453, -0.5063657])"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data = np.array([1, 3, 20, 100]).astype('int')\n",
+    "a = IntTensor(data)\n",
+    "a.sin().to_numpy()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<b>cos()</b>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 0.5403023, -0.9899925,  0.4080821,  0.8623189])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data = np.array([1, 3, 20, 100]).astype('int')\n",
+    "a = IntTensor(data)\n",
+    "a.cos().to_numpy()"
    ]
   },
   {


### PR DESCRIPTION
# Description

This pull request resolves issue #830 . This pull request is the Openmined Unity portion of the implementation. See comment below for the pull request of the PySyft portion.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Added unit tests, integration tests and jupyter notebook example


## How Has This Been Tested?
- [x] Created and ran unit tests in unity
- [x] Created and ran integration tests in Openmined/integration
- [x] Created an example in Openmined/notebooks/tests/Test Tensor Function Implementation.ipynb 

**Test Configuration**:
* CPU: Macbook Pro (intel core i7)
* GPU: AMD Radeon R9 M370X
* PySyft Version: 0.1
* Unity Version: 2017.2.0f3
* OpenMined Unity App Version: Latest

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules