### PR TITLE
Implement Unfold function for IntTensor in Unity, fixes OpenMined/PySyft#1266

### DIFF
--- a/UnityProject/Assets/OpenMined.Tests/Editor/IntTensor/IntTensorTest.cs
+++ b/UnityProject/Assets/OpenMined.Tests/Editor/IntTensor/IntTensorTest.cs
@@ -766,6 +766,45 @@ namespace OpenMined.Tests.Editor.IntTensorTests
             }
         }
 
+        [Test]
+        public void Unfold()
+        {
+            int[] input_data = {-1, 2, 3, 5, 0, 4, 6, 7, 10, 3, 2, -5};
+            int[] input_shape = {3, 4};
+
+            var input_tensor = ctrl.intTensorFactory.Create(_data: input_data, _shape: input_shape);
+
+            // Test1
+            int dim = 0;
+            int step = 1;
+            int size = 2;
+            int[] expected_data = {-1, 2, 3, 5, 0, 4, 6, 7, 0, 4, 6, 7, 10, 3, 2, -5};
+            int[] expected_shape = {2, 2, 4};
+            var expected_output_tensor = ctrl.intTensorFactory.Create(_data: expected_data, _shape: expected_shape);
+
+            var actual_output_tensor = input_tensor.Unfold(dim: dim, step: step, size: size);
+            
+            for (int i = 0; i<actual_output_tensor.Size; i++)
+            {
+                Assert.AreEqual(expected_output_tensor[i], actual_output_tensor[i]);
+            }
+
+            // Test2
+            dim = 1;
+            step = 1;
+            size = 3;
+            int[] expected_data2 = {-1, 2, 3, 0, 4, 6, 10, 3, 2, 2, 3, 5, 4, 6, 7, 3, 2, -5};
+            int[] expected_shape2 = {2, 3, 3};
+            var expected_output_tensor2 = ctrl.intTensorFactory.Create(_data: expected_data2, _shape: expected_shape2);
+
+            actual_output_tensor = input_tensor.Unfold(dim: dim, step: step, size: size);
+            
+            for (int i = 0; i<actual_output_tensor.Size; i++)
+            {
+                Assert.AreEqual(expected_output_tensor2[i], actual_output_tensor[i]);
+            }
+        }
+
         /* closes class and namespace */
     }
 }

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/IntTensor.Ops.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/IntTensor.Ops.cs
@@ -488,6 +488,63 @@ namespace OpenMined.Syft.Tensor
             return Enumerable.Range(0, shape.Min()).AsParallel().Select(i => this[i * stride]).Sum();
         }
 
+        public IntTensor Unfold(int dim, int size, int step, bool inline = false)
+        {
+            // Getting the number of new tensors to add
+            int new_dim_size = Mathf.CeilToInt ((this.shape [dim] - size + 1) / (float)step);
+            
+            // Declaring required variables
+            int[] new_shape = new int[this.shape.Count() + 1];
+            long newTensorSize = 1;
+            int dimSize = this.shape[dim];
+            int sizeBeforeDim = 1;
+            int sizeAfterDim = 1;
+
+            for(int i=0; i < new_shape.Count(); i++){
+                if (i == 0){
+                    new_shape[i] = new_dim_size;
+                }
+                else if ((i - 1) == dim){
+                    new_shape[i] = size;
+                } else {
+                    new_shape[i] = this.shape[i-1];
+                }
+                
+                if ((i != 0) && ((i-1) < dim)){
+                    sizeBeforeDim *= new_shape[i];
+                }
+                if ((i-1) > dim){
+                    sizeAfterDim *= new_shape[i];
+                }
+
+                newTensorSize *= new_shape[i];
+            }
+            
+            if (dataOnGpu) {
+                throw new NotImplementedException ();
+            } else {
+                if (inline) {
+                    throw new NotImplementedException ();
+                } else {
+                    IntTensor result = factory.Create (new_shape);
+                    Parallel.For(0, newTensorSize, index => {
+                        // Calculating the offset due to step
+                        int currentStep = (int) (index/(sizeBeforeDim * size * sizeAfterDim));
+                        int updatedIndex = (int) (index % (sizeBeforeDim * size * sizeAfterDim));
+                        int stepOffset = currentStep * sizeAfterDim * step;
+
+                        // Calculating the offset due to size difference of dim
+                        int sizeIndex = (int) (updatedIndex/(size * sizeAfterDim));
+                        int sizeOffset = sizeIndex * (dimSize - size) * sizeAfterDim;
+
+                        int indexToQuery = updatedIndex + stepOffset + sizeOffset;
+                        result.data[index] = data[indexToQuery];
+                    });
+                    return result;
+                }
+            }
+        }
+
         public IntTensor TopK(int k, int dim = -1, bool largest = true , bool sorted= true,  bool inline = false)
         {
             if (dataOnGpu)

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/IntTensor.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/IntTensor.cs
@@ -460,6 +460,16 @@ namespace OpenMined.Syft.Tensor
                     View(new_dims, inline: true);
                     return Id.ToString();
                 }
+
+                case "unfold":
+                {
+                    int dim = int.Parse (msgObj.tensorIndexParams [0]);
+                    int size = int.Parse (msgObj.tensorIndexParams [1]);
+                    int step = int.Parse (msgObj.tensorIndexParams [2]);
+                    
+                    var result = Unfold (dim, size, step);
+                    return result.Id.ToString ();
+                }
                 
                 case "to_numpy_by_proto":
                 {

--- a/notebooks/tests/Test Tensor Function Implementations.ipynb
+++ b/notebooks/tests/Test Tensor Function Implementations.ipynb
@@ -1452,6 +1452,84 @@
    },
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "**unfold()**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = np.array([[-1, 2, 3, 5], [0, 4, 6, 7], [10, 3, 2, -5]], dtype=np.int32)\n",
+    "a = IntTensor(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[[[-1  2  3  5]\n",
+       "  [ 0  4  6  7]]\n",
+       "\n",
+       " [[ 0  4  6  7]\n",
+       "  [10  3  2 -5]]]\n",
+       "[syft.IntTensor:2 size:2x2x4]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a.unfold(dim=0, step=1, size=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[[[-1  2  3]\n",
+       "  [ 0  4  6]\n",
+       "  [10  3  2]]\n",
+       "\n",
+       " [[ 2  3  5]\n",
+       "  [ 4  6  7]\n",
+       "  [ 3  2 -5]]]\n",
+       "[syft.IntTensor:3 size:2x3x3]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a.unfold(dim=1, step=1, size=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
# Description

This PR adds the unfold function for IntTensor OpenMined/PySyft#1266

Fixes OpenMined/PySyft#1266

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Implemented unit tests in Unity that can be run under Unity/Window/Test Runner/.../IntTensorTests/IntTensorCPUTest/Unfold

**Test Configuration**:
* CPU: Intel Code i7 (4th Gen), Jupyter Notebook, Python 3.6
* GPU: n/a
* PySyft Version: 0.1.0
* Unity Version: 2017.2.0f3 Personal
* OpenMined Unity App Version: latest

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
