### PR TITLE
implement the Add function and inline Add function for IntTensor on the CPU

### DIFF
--- a/UnityProject/Assets/OpenMined.Tests/Editor/IntTensor/IntTensorTest.cs
+++ b/UnityProject/Assets/OpenMined.Tests/Editor/IntTensor/IntTensorTest.cs
@@ -101,13 +101,13 @@ namespace OpenMined.Tests.Editor.IntTensorTests
         [Test]
         public void Add()
         {
-            float[] data1 = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            int[] data1 = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
             int[] shape1 = { 2, 5 };
-            var tensor1 = ctrl.floatTensorFactory.Create(_data: data1, _shape: shape1);
+            var tensor1 = ctrl.intTensorFactory.Create(_data: data1, _shape: shape1);
 
-            float[] data2 = { 3, 2, 6, 9, 10, 1, 4, 8, 5, 7 };
+            int[] data2 = { 3, 2, 6, 9, 10, 1, 4, 8, 5, 7 };
             int[] shape2 = { 2, 5 };
-            var tensor2 = ctrl.floatTensorFactory.Create(_data: data2, _shape: shape2);
+            var tensor2 = ctrl.intTensorFactory.Create(_data: data2, _shape: shape2);
 
             var tensorSum = tensor1.Add(tensor2);
 
@@ -120,23 +120,61 @@ namespace OpenMined.Tests.Editor.IntTensorTests
         [Test]
         public void Add_()
         {
-            float[] data1 = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            int[] data1 = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
             int[] shape1 = { 2, 5 };
-            var tensor1 = ctrl.floatTensorFactory.Create(_data: data1, _shape: shape1);
+            var tensor1 = ctrl.intTensorFactory.Create(_data: data1, _shape: shape1);
 
-            float[] data2 = { 3, 2, 6, 9, 10, 1, 4, 8, 5, 7 };
+            int[] data2 = { 3, 2, 6, 9, 10, 1, 4, 8, 5, 7 };
             int[] shape2 = { 2, 5 };
-            var tensor2 = ctrl.floatTensorFactory.Create(_data: data2, _shape: shape2);
+            var tensor2 = ctrl.intTensorFactory.Create(_data: data2, _shape: shape2);
 
-            float[] data3 = { 4, 4, 9, 13, 15, 7, 11, 16, 14, 17 };
+            int[] data3 = { 4, 4, 9, 13, 15, 7, 11, 16, 14, 17 };
             int[] shape3 = { 2, 5 };
-            var tensor3 = ctrl.floatTensorFactory.Create(_data: data3, _shape: shape3);
+            var tensor3 = ctrl.intTensorFactory.Create(_data: data3, _shape: shape3);
 
             tensor1.Add(tensor2, inline: true);
 
             for (int i = 0; i < tensor1.Size; i++)
             {
                 Assert.AreEqual(tensor3[i], tensor1[i]);
+            }
+        }
+
+        [Test]
+        public void AddScalar()
+        {
+            int[] data1 = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            int[] shape1 = { 2, 5 };
+            var tensor1 = ctrl.intTensorFactory.Create(_data: data1, _shape: shape1);
+
+            int scalar = 5;
+
+            var tensorSum = tensor1.Add(scalar);
+
+            for (int i = 0; i < tensorSum.Size; i++)
+            {
+                Assert.AreEqual(tensor1[i] + scalar, tensorSum[i]);
+            }
+        }
+
+        [Test]
+        public void AddScalar_()
+        {
+            int[] data1 = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            int[] shape1 = { 2, 5 };
+            var tensor1 = ctrl.intTensorFactory.Create(_data: data1, _shape: shape1);
+
+            int scalar = -5;
+
+            int[] data2 = { -4, -3, -2, -1,  0,  1,  2,  3,  4,  5 };
+            int[] shape2 = { 2, 5 };
+            var tensor2 = ctrl.intTensorFactory.Create(_data: data2, _shape: shape2);
+
+            tensor1.Add(scalar, inline: true);
+
+            for (int i = 0; i < tensor1.Size; i++)
+            {
+                Assert.AreEqual(tensor2[i], tensor1[i]);
             }
         }
 

--- a/UnityProject/Assets/OpenMined/Syft/Tensor/IntTensor.Ops.cs
+++ b/UnityProject/Assets/OpenMined/Syft/Tensor/IntTensor.Ops.cs
@@ -16,9 +16,15 @@ namespace OpenMined.Syft.Tensor
             }
 
             IntTensor result = factory.Create(this.shape);
-            result.Data = data.AsParallel().Select(x => x + value).ToArray();
-
-            return result;
+            if (inline) {
+                Data = data.AsParallel().Select(x => x + value).ToArray();
+                return this;
+            }
+            else
+            {
+                result.Data = data.AsParallel().Select(x => x + value).ToArray();
+                return result;
+            }
         }
 
         public FloatTensor Acos(bool inline = false)
@@ -48,9 +54,15 @@ namespace OpenMined.Syft.Tensor
             else
             {
                 // run Addition on the CPU
-                result.Data = data.AsParallel().Zip(x.Data.AsParallel(), (a, b) => a + b).ToArray();
-
-                return result;
+                if (inline) {
+                    Data = data.AsParallel().Zip(x.Data.AsParallel(), (a, b) => a + b).ToArray();
+                    return this;
+                }
+                else
+                {
+                    result.Data = data.AsParallel().Zip(x.Data.AsParallel(), (a, b) => a + b).ToArray();
+                    return result;
+                }
             }
 
         }


### PR DESCRIPTION
# Description

Added initial support for addition and inline addition on the CPU for IntTensor.

Fix the IntTensor tests: Add and Add_ to actually test the IntTensor addition function (before it was testing the FloatTensor). Write additional IntTensor tests for AddScalar and AddScalar_. These unit tests are modified from the FloatTensorCPUTest and they pass.

Fixes # (issue)

https://github.com/OpenMined/PySyft/issues/766
https://github.com/OpenMined/PySyft/issues/767

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Added tests for an existing feature

# How Has This Been Tested?

- [x] Add, Add_, AddScalar, AddScalar_ tests in IntTensorTest.cs

These unit tests are modified from the FloatTensorCPUTest, using intTensorFactory instead.

**Test Configuration**:
* CPU: Mac OS High Sierra 10.13.3
* GPU: Radeon Pro 455 2 GB, Intel HD Graphics 530 1536 MB
* PySyft Version: 0.1
* Unity Version: 2017.3.1f1
* OpenMined Unity App Version: 2017.3.0f3

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
